### PR TITLE
Add type information to visitEquipment

### DIFF
--- a/iidm-network-api/src/main/java/eu/itesla_project/iidm/network/EquipmentTopologyVisitor.java
+++ b/iidm-network-api/src/main/java/eu/itesla_project/iidm/network/EquipmentTopologyVisitor.java
@@ -12,7 +12,7 @@ package eu.itesla_project.iidm.network;
  */
 public abstract class EquipmentTopologyVisitor extends AbstractTopologyVisitor {
 
-    public abstract void visitEquipment(Connectable eq);
+    public abstract <I extends Connectable<I>> void visitEquipment(Connectable<I> eq);
 
     @Override
     public void visitLine(Line line, TwoTerminalsConnectable.Side side) {


### PR DESCRIPTION
for Connectable in EquipmentTopologyVisitor to avoid compilation warning ```Connectable is a raw type. References to generic type Connectable<I> should be parameterized```