### PR TITLE
ZipFileDatasource performance issue

### DIFF
--- a/iidm-converter-api/pom.xml
+++ b/iidm-converter-api/pom.xml
@@ -62,6 +62,10 @@
             <artifactId>commons-compress</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.java.truevfs</groupId>
+            <artifactId>truevfs-driver-zip</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -79,11 +83,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <jimfs.version>1.1</jimfs.version>
         <groovyeclipsecompiler.version>2.9.2-01</groovyeclipsecompiler.version>
         <groovyeclipsebatch.version>2.4.3-01</groovyeclipsebatch.version>
+        <truevfs.version>0.11.1</truevfs.version>
     </properties>
 
     <licenses>
@@ -334,11 +335,15 @@
                 <artifactId>groovy-all</artifactId>
                 <version>${groovy.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>com.google.jimfs</groupId>
                 <artifactId>jimfs</artifactId>
                 <version>${jimfs.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.truevfs</groupId>
+                <artifactId>truevfs-driver-zip</artifactId>
+                <version>${truevfs.version}</version>
             </dependency>
 
 


### PR DESCRIPTION
Performance issue since ZipInputStream is used in place of ZipFile (because ZipFile is not in memory testable). The exists method of ZipFileDatasource in now very slow because to check if an entry exists, the full zip file is scannned. On the contrary, using ZipFile only the central directory in scanned which is very fast. An alternative implementation of ZipFile (from TrueVFS) which can take a Path as  a parameter in now used.