### PR TITLE
Set the maxOccurs for the extensions to unbound

### DIFF
--- a/iidm/iidm-xml-converter/src/main/resources/xsd/iidm.xsd
+++ b/iidm/iidm-xml-converter/src/main/resources/xsd/iidm.xsd
@@ -29,7 +29,7 @@
                  <xs:element name="extension" minOccurs="0" maxOccurs="unbounded">
                      <xs:complexType>
                          <xs:sequence>
-                             <xs:any minOccurs="1"/>
+                             <xs:any minOccurs="1" maxOccurs="unbounded"/>
                          </xs:sequence>
                          <xs:attribute name="id" use="required" type="xs:string"/>
                      </xs:complexType>


### PR DESCRIPTION
Unable to validate an IIDM file against the schema if several extensions are defined for an Identifiable