### PR TITLE
SecurityAnalysis without contingencies

### DIFF
--- a/contingency-api/src/main/java/eu/itesla_project/contingency/EmptyContingencyListProvider.java
+++ b/contingency-api/src/main/java/eu/itesla_project/contingency/EmptyContingencyListProvider.java
@@ -4,10 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package eu.itesla_project.contingency.mock;
+package eu.itesla_project.contingency;
 
-import eu.itesla_project.contingency.ContingenciesProvider;
-import eu.itesla_project.contingency.Contingency;
 import eu.itesla_project.iidm.network.Network;
 
 import java.util.Collections;
@@ -16,7 +14,7 @@ import java.util.List;
 /**
  * @author Mathieu Bague <mathieu.bague at rte-france.com>
  */
-public class ContingenciesProviderMock implements ContingenciesProvider {
+public class EmptyContingencyListProvider implements ContingenciesProvider {
 
     @Override
     public List<Contingency> getContingencies(Network network) {

--- a/contingency-api/src/main/java/eu/itesla_project/contingency/EmptyContingencyListProviderFactory.java
+++ b/contingency-api/src/main/java/eu/itesla_project/contingency/EmptyContingencyListProviderFactory.java
@@ -4,18 +4,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package eu.itesla_project.contingency.mock;
-
-import eu.itesla_project.contingency.ContingenciesProvider;
-import eu.itesla_project.contingency.ContingenciesProviderFactory;
+package eu.itesla_project.contingency;
 
 /**
  * @author Mathieu Bague <mathieu.bague at rte-france.com>
  */
-public class ContingenciesProviderFactoryMock implements ContingenciesProviderFactory {
+public class EmptyContingencyListProviderFactory implements ContingenciesProviderFactory {
 
     @Override
     public ContingenciesProvider create() {
-        return new ContingenciesProviderMock();
+        return new EmptyContingencyListProvider();
     }
 }

--- a/contingency-api/src/main/java/eu/itesla_project/contingency/mock/ContingenciesProviderMock.java
+++ b/contingency-api/src/main/java/eu/itesla_project/contingency/mock/ContingenciesProviderMock.java
@@ -16,7 +16,7 @@ import java.util.List;
 /**
  * @author Mathieu Bague <mathieu.bague at rte-france.com>
  */
-class ContingenciesProviderMock implements ContingenciesProvider {
+public class ContingenciesProviderMock implements ContingenciesProvider {
 
     @Override
     public List<Contingency> getContingencies(Network network) {

--- a/contingency-api/src/test/java/eu/itesla_project/contingency/EmptyContingencyListProviderTest.java
+++ b/contingency-api/src/test/java/eu/itesla_project/contingency/EmptyContingencyListProviderTest.java
@@ -4,24 +4,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package eu.itesla_project.contingency.mock;
+package eu.itesla_project.contingency;
 
-import eu.itesla_project.contingency.ContingenciesProvider;
-import eu.itesla_project.contingency.ContingenciesProviderFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
 /**
  * @author Mathieu Bague <mathieu.bague at rte-france.com>
  */
-public class ContingenciesProviderTest {
+public class EmptyContingencyListProviderTest {
 
     @Test
     public void test() {
-        ContingenciesProviderFactory factory = new ContingenciesProviderFactoryMock();
+        ContingenciesProviderFactory factory = new EmptyContingencyListProviderFactory();
         ContingenciesProvider provider = factory.create();
 
-        Assert.assertTrue(provider instanceof ContingenciesProviderMock);
+        Assert.assertTrue(provider instanceof EmptyContingencyListProvider);
         Assert.assertEquals(0, provider.getContingencies(null).size());
     }
 }

--- a/security-analysis/src/main/java/eu/itesla_project/security/SecurityAnalyzer.java
+++ b/security-analysis/src/main/java/eu/itesla_project/security/SecurityAnalyzer.java
@@ -6,16 +6,16 @@
  */
 package eu.itesla_project.security;
 
-import java.nio.file.Path;
-import java.util.Objects;
-
 import eu.itesla_project.commons.config.ComponentDefaultConfig;
 import eu.itesla_project.computation.ComputationManager;
 import eu.itesla_project.contingency.ContingenciesProvider;
 import eu.itesla_project.contingency.ContingenciesProviderFactory;
-
+import eu.itesla_project.contingency.mock.ContingenciesProviderMock;
 import eu.itesla_project.iidm.import_.Importers;
 import eu.itesla_project.iidm.network.Network;
+
+import java.nio.file.Path;
+import java.util.Objects;
 
 /**
  * @author Giovanni Ferrari <giovanni.ferrari@techrain.it>
@@ -35,13 +35,12 @@ public class SecurityAnalyzer {
         contingenciesProviderFactory = defaultConfig.newFactoryImpl(ContingenciesProviderFactory.class);
     }
     
-    public SecurityAnalyzer(ComputationManager computationManager, int priority, SecurityAnalysisFactory securityAnalysisFactory, ContingenciesProviderFactory contingenciesProviderFactory){
+    public SecurityAnalyzer(ComputationManager computationManager, int priority, SecurityAnalysisFactory securityAnalysisFactory, ContingenciesProviderFactory contingenciesProviderFactory) {
         this.computationManager = Objects.requireNonNull(computationManager);
         this.priority = priority;
         this.securityAnalysisFactory = Objects.requireNonNull(securityAnalysisFactory);
         this.contingenciesProviderFactory = Objects.requireNonNull(contingenciesProviderFactory);
     }
-
 
     public SecurityAnalysisResult analyze(Path caseFile, Path contingenciesFile) {
         Objects.requireNonNull(caseFile);
@@ -55,11 +54,9 @@ public class SecurityAnalyzer {
         SecurityAnalysis securityAnalysis = securityAnalysisFactory.create(network, computationManager, priority);
 
         ContingenciesProvider contingenciesProvider = contingenciesFile != null
-                ? contingenciesProviderFactory.create(contingenciesFile) : contingenciesProviderFactory.create();
+                ? contingenciesProviderFactory.create(contingenciesFile) : new ContingenciesProviderMock();
 
-        // run security analysis on all N-1 lines
         return securityAnalysis.runAsync(contingenciesProvider).join();
-
     }
 
 }

--- a/security-analysis/src/main/java/eu/itesla_project/security/SecurityAnalyzer.java
+++ b/security-analysis/src/main/java/eu/itesla_project/security/SecurityAnalyzer.java
@@ -10,7 +10,7 @@ import eu.itesla_project.commons.config.ComponentDefaultConfig;
 import eu.itesla_project.computation.ComputationManager;
 import eu.itesla_project.contingency.ContingenciesProvider;
 import eu.itesla_project.contingency.ContingenciesProviderFactory;
-import eu.itesla_project.contingency.mock.ContingenciesProviderMock;
+import eu.itesla_project.contingency.EmptyContingencyListProvider;
 import eu.itesla_project.iidm.import_.Importers;
 import eu.itesla_project.iidm.network.Network;
 
@@ -54,7 +54,7 @@ public class SecurityAnalyzer {
         SecurityAnalysis securityAnalysis = securityAnalysisFactory.create(network, computationManager, priority);
 
         ContingenciesProvider contingenciesProvider = contingenciesFile != null
-                ? contingenciesProviderFactory.create(contingenciesFile) : new ContingenciesProviderMock();
+                ? contingenciesProviderFactory.create(contingenciesFile) : new EmptyContingencyListProvider();
 
         return securityAnalysis.runAsync(contingenciesProvider).join();
     }


### PR DESCRIPTION
If the contingencies-file option is not pass to the command line, use the ContingenciesProviderMock instead of the default one