### PR TITLE
Improve security-analysis results

### DIFF
--- a/action/action-simulator/src/main/java/eu/itesla_project/action/simulator/loadflow/LoadFlowActionSimulator.java
+++ b/action/action-simulator/src/main/java/eu/itesla_project/action/simulator/loadflow/LoadFlowActionSimulator.java
@@ -9,8 +9,6 @@ package eu.itesla_project.action.simulator.loadflow;
 import eu.itesla_project.action.dsl.*;
 import eu.itesla_project.action.dsl.ast.*;
 import eu.itesla_project.action.simulator.ActionSimulator;
-import eu.itesla_project.commons.exceptions.UncheckedIllegalAccessException;
-import eu.itesla_project.commons.exceptions.UncheckedInstantiationException;
 import eu.itesla_project.computation.ComputationManager;
 import eu.itesla_project.contingency.Contingency;
 import eu.itesla_project.iidm.network.Network;
@@ -117,14 +115,8 @@ public class LoadFlowActionSimulator implements ActionSimulator {
         }
     }
 
-    protected LoadFlowFactory newLoadLoadLowFactory() {
-        try {
-            return config.getLoadFlowFactoryClass().newInstance();
-        } catch (InstantiationException e) {
-            throw new UncheckedInstantiationException(e);
-        } catch (IllegalAccessException e) {
-            throw new UncheckedIllegalAccessException(e);
-        }
+    protected LoadFlowFactory newLoadLoadLowFactory() throws InstantiationException, IllegalAccessException {
+        return config.getLoadFlowFactoryClass().newInstance();
     }
 
     private boolean next(ActionDb actionDb, RunningContext context) {
@@ -132,143 +124,142 @@ public class LoadFlowActionSimulator implements ActionSimulator {
             return false;
         }
 
-        if (observers != null) {
-            observers.forEach(o -> o.roundBegin(context.getContingency(), context.getRound()));
-        }
-
-        LoadFlowFactory loadFlowFactory = newLoadLoadLowFactory();
-        LoadFlow loadFlow = loadFlowFactory.create(context.getNetwork(), computationManager, 0);
-
-        LOGGER.info("Running loadflow ({})", loadFlow.getName());
-        LoadFlowResult result;
         try {
-            result = loadFlow.run();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        if (result.isOk()) {
-            List<LimitViolation> violations = LIMIT_VIOLATION_FILTER.apply(Security.checkLimits(context.getNetwork(), Security.CurrentLimitType.TATL, 1));
-            if (violations.size() > 0) {
-                LOGGER.info("Violations: \n{}", Security.printLimitsViolations(violations, NO_FILTER));
-            }
             if (observers != null) {
-                observers.forEach(o -> o.loadFlowConverged(context.getContingency(), violations));
+                observers.forEach(o -> o.roundBegin(context.getContingency(), context.getRound()));
             }
 
-            // no more violations => work complete
-            if (violations.isEmpty()) {
-                LOGGER.info("No more violation");
-                if (observers != null) {
-                    observers.forEach(o -> o.noMoreViolations(context.getContingency()));
+            LoadFlowFactory loadFlowFactory = newLoadLoadLowFactory();
+            LoadFlow loadFlow = loadFlowFactory.create(context.getNetwork(), computationManager, 0);
+
+            LOGGER.info("Running loadflow ({})", loadFlow.getName());
+            LoadFlowResult result = loadFlow.run();
+            if (result.isOk()) {
+                List<LimitViolation> violations = LIMIT_VIOLATION_FILTER.apply(Security.checkLimits(context.getNetwork(), 1));
+                if (violations.size() > 0) {
+                    LOGGER.info("Violations: \n{}", Security.printLimitsViolations(violations, NO_FILTER));
                 }
-                return true;
-            }
+                if (observers != null) {
+                    observers.forEach(o -> o.loadFlowConverged(context.getContingency(), violations));
+                }
 
-            Set<String> actionsTaken = new HashSet<>();
-            for (Rule rule : actionDb.getRules()) {
-
-                RuleEvaluationStatus status;
-                final Map<String, Object> variables;
-                final Map<String, Boolean> actions;
-                if (context.getRuleMatchCount(rule.getId()) >= rule.getLife()) {
-                    status = RuleEvaluationStatus.DEAD;
-                    variables = Collections.emptyMap();
-                    actions = Collections.emptyMap();
-                } else {
-                    // re-evaluate the condition
-                    if (rule.getCondition().getType() != ConditionType.EXPRESSION) {
-                        throw new AssertionError("TODO");
+                // no more violations => work complete
+                if (violations.isEmpty()) {
+                    LOGGER.info("No more violation");
+                    if (observers != null) {
+                        observers.forEach(o -> o.noMoreViolations(context.getContingency()));
                     }
-                    ExpressionNode conditionExpr = ((ExpressionCondition) rule.getCondition()).getNode();
-                    EvaluationContext evalContext = new EvaluationContext() {
-                        @Override
-                        public Network getNetwork() {
-                            return context.getNetwork();
-                        }
+                    return true;
+                }
 
-                        @Override
-                        public Contingency getContingency() {
-                            return context.getContingency();
-                        }
+                Set<String> actionsTaken = new HashSet<>();
+                for (Rule rule : actionDb.getRules()) {
 
-                        @Override
-                        public boolean isActionTaken(String actionId) {
-                            return context.getTimeLine().actionTaken(actionId);
-                        }
-                    };
-                    boolean ok = ExpressionEvaluator.evaluate(conditionExpr, evalContext).equals(Boolean.TRUE);
-
-                    LOGGER.debug("Evaluating {} to {}", ExpressionPrinter.toString(conditionExpr), Boolean.toString(ok));
-
-                    variables = ExpressionVariableLister.list(conditionExpr).stream()
-                        .collect(Collectors.toMap(ExpressionPrinter::toString,
-                            n -> ExpressionEvaluator.evaluate(n, evalContext),
-                            (v1, v2) -> v1,
-                            TreeMap::new));
-
-                    LOGGER.debug("Variables values: {}", variables);
-
-                    if (ok) {
-                        status = RuleEvaluationStatus.TRUE;
-                        context.incrementRuleMatchCount(rule.getId());
+                    RuleEvaluationStatus status;
+                    final Map<String, Object> variables;
+                    final Map<String, Boolean> actions;
+                    if (context.getRuleMatchCount(rule.getId()) >= rule.getLife()) {
+                        status = RuleEvaluationStatus.DEAD;
+                        variables = Collections.emptyMap();
+                        actions = Collections.emptyMap();
                     } else {
-                        status = RuleEvaluationStatus.FALSE;
+                        // re-evaluate the condition
+                        if (rule.getCondition().getType() != ConditionType.EXPRESSION) {
+                            throw new AssertionError("TODO");
+                        }
+                        ExpressionNode conditionExpr = ((ExpressionCondition) rule.getCondition()).getNode();
+                        EvaluationContext evalContext = new EvaluationContext() {
+                            @Override
+                            public Network getNetwork() {
+                                return context.getNetwork();
+                            }
+
+                            @Override
+                            public Contingency getContingency() {
+                                return context.getContingency();
+                            }
+
+                            @Override
+                            public boolean isActionTaken(String actionId) {
+                                return context.getTimeLine().actionTaken(actionId);
+                            }
+                        };
+                        boolean ok = ExpressionEvaluator.evaluate(conditionExpr, evalContext).equals(Boolean.TRUE);
+
+                        LOGGER.debug("Evaluating {} to {}", ExpressionPrinter.toString(conditionExpr), Boolean.toString(ok));
+
+                        variables = ExpressionVariableLister.list(conditionExpr).stream()
+                            .collect(Collectors.toMap(ExpressionPrinter::toString,
+                                n -> ExpressionEvaluator.evaluate(n, evalContext),
+                                (v1, v2) -> v1,
+                                TreeMap::new));
+
+                        LOGGER.debug("Variables values: {}", variables);
+
+                        if (ok) {
+                            status = RuleEvaluationStatus.TRUE;
+                            context.incrementRuleMatchCount(rule.getId());
+                        } else {
+                            status = RuleEvaluationStatus.FALSE;
+                        }
+
+                        actions = ExpressionActionTakenLister.list(conditionExpr).stream()
+                            .collect(Collectors.toMap(s -> s,
+                                s -> context.getTimeLine().actionTaken(s),
+                                (s1, s2) -> s1,
+                                TreeMap::new));
                     }
 
-                    actions = ExpressionActionTakenLister.list(conditionExpr).stream()
-                        .collect(Collectors.toMap(s -> s,
-                            s -> context.getTimeLine().actionTaken(s),
-                            (s1, s2) -> s1,
-                            TreeMap::new));
+                    if (observers != null) {
+                        observers.forEach(o -> o.ruleChecked(context.getContingency(), rule, status, variables, actions));
+                    }
+
+                    if (status == RuleEvaluationStatus.TRUE) {
+                        for (String actionId : rule.getActions()) {
+                            Action action = actionDb.getAction(actionId);
+
+                            // apply action
+                            LOGGER.info("Apply action '{}'", action.getId());
+                            if (observers != null) {
+                                observers.forEach(o-> o.beforeAction(context.getContingency(), actionId));
+                            }
+
+                            action.run(context.getNetwork(), computationManager);
+
+                            if (observers != null) {
+                                observers.forEach(o-> o.afterAction(context.getContingency(), actionId));
+                            }
+                            actionsTaken.add(actionId);
+                        }
+                    }
                 }
+
+                // record the action in the time line
+                context.getTimeLine().getActions().addAll(actionsTaken);
 
                 if (observers != null) {
-                    observers.forEach(o -> o.ruleChecked(context.getContingency(), rule, status, variables, actions));
+                    observers.forEach(o -> o.roundEnd(context.getContingency(), context.getRound()));
                 }
 
-                if (status == RuleEvaluationStatus.TRUE) {
-                    for (String actionId : rule.getActions()) {
-                        Action action = actionDb.getAction(actionId);
-
-                        // apply action
-                        LOGGER.info("Apply action '{}'", action.getId());
-                        if (observers != null) {
-                            observers.forEach(o-> o.beforeAction(context.getContingency(), actionId));
-                        }
-
-                        action.run(context.getNetwork(), computationManager);
-
-                        if (observers != null) {
-                            observers.forEach(o-> o.afterAction(context.getContingency(), actionId));
-                        }
-                        actionsTaken.add(actionId);
+                if (actionsTaken.size() > 0) {
+                    context.setRound(context.getRound() + 1);
+                    return next(actionDb, context);
+                } else {
+                    LOGGER.info("Still some violations and no rule match");
+                    if (observers != null) {
+                        observers.forEach(o -> o.violationsAnymoreAndNoRulesMatch(context.getContingency()));
                     }
+                    return false;
                 }
-            }
-
-            // record the action in the time line
-            context.getTimeLine().getActions().addAll(actionsTaken);
-
-            if (observers != null) {
-                observers.forEach(o -> o.roundEnd(context.getContingency(), context.getRound()));
-            }
-
-            if (actionsTaken.size() > 0) {
-                context.setRound(context.getRound() + 1);
-                return next(actionDb, context);
             } else {
-                LOGGER.info("Still some violations and no rule match");
+                LOGGER.warn("Loadflow diverged: {}", result.getMetrics());
                 if (observers != null) {
-                    observers.forEach(o -> o.violationsAnymoreAndNoRulesMatch(context.getContingency()));
+                    observers.forEach(o -> o.loadFlowDiverged(context.getContingency()));
                 }
                 return false;
             }
-        } else {
-            LOGGER.warn("Loadflow diverged: {}", result.getMetrics());
-            if (observers != null) {
-                observers.forEach(o -> o.loadFlowDiverged(context.getContingency()));
-            }
-            return false;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/action/action-simulator/src/main/java/eu/itesla_project/action/simulator/loadflow/LoadFlowActionSimulator.java
+++ b/action/action-simulator/src/main/java/eu/itesla_project/action/simulator/loadflow/LoadFlowActionSimulator.java
@@ -9,6 +9,8 @@ package eu.itesla_project.action.simulator.loadflow;
 import eu.itesla_project.action.dsl.*;
 import eu.itesla_project.action.dsl.ast.*;
 import eu.itesla_project.action.simulator.ActionSimulator;
+import eu.itesla_project.commons.exceptions.UncheckedIllegalAccessException;
+import eu.itesla_project.commons.exceptions.UncheckedInstantiationException;
 import eu.itesla_project.computation.ComputationManager;
 import eu.itesla_project.contingency.Contingency;
 import eu.itesla_project.iidm.network.Network;
@@ -115,8 +117,14 @@ public class LoadFlowActionSimulator implements ActionSimulator {
         }
     }
 
-    protected LoadFlowFactory newLoadLoadLowFactory() throws InstantiationException, IllegalAccessException {
-        return config.getLoadFlowFactoryClass().newInstance();
+    protected LoadFlowFactory newLoadFlowFactory() {
+        try {
+            return config.getLoadFlowFactoryClass().newInstance();
+        } catch (InstantiationException e) {
+            throw new UncheckedInstantiationException(e);
+        } catch (IllegalAccessException e) {
+            throw new UncheckedIllegalAccessException(e);
+        }
     }
 
     private boolean next(ActionDb actionDb, RunningContext context) {
@@ -124,142 +132,143 @@ public class LoadFlowActionSimulator implements ActionSimulator {
             return false;
         }
 
+        if (observers != null) {
+            observers.forEach(o -> o.roundBegin(context.getContingency(), context.getRound()));
+        }
+
+        LoadFlowFactory loadFlowFactory = newLoadFlowFactory();
+        LoadFlow loadFlow = loadFlowFactory.create(context.getNetwork(), computationManager, 0);
+
+        LOGGER.info("Running loadflow ({})", loadFlow.getName());
+        LoadFlowResult result;
         try {
+            result = loadFlow.run();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        if (result.isOk()) {
+            List<LimitViolation> violations = LIMIT_VIOLATION_FILTER.apply(Security.checkLimits(context.getNetwork(), 1));
+            if (violations.size() > 0) {
+                LOGGER.info("Violations: \n{}", Security.printLimitsViolations(violations, NO_FILTER));
+            }
             if (observers != null) {
-                observers.forEach(o -> o.roundBegin(context.getContingency(), context.getRound()));
+                observers.forEach(o -> o.loadFlowConverged(context.getContingency(), violations));
             }
 
-            LoadFlowFactory loadFlowFactory = newLoadLoadLowFactory();
-            LoadFlow loadFlow = loadFlowFactory.create(context.getNetwork(), computationManager, 0);
-
-            LOGGER.info("Running loadflow ({})", loadFlow.getName());
-            LoadFlowResult result = loadFlow.run();
-            if (result.isOk()) {
-                List<LimitViolation> violations = LIMIT_VIOLATION_FILTER.apply(Security.checkLimits(context.getNetwork(), 1));
-                if (violations.size() > 0) {
-                    LOGGER.info("Violations: \n{}", Security.printLimitsViolations(violations, NO_FILTER));
-                }
+            // no more violations => work complete
+            if (violations.isEmpty()) {
+                LOGGER.info("No more violation");
                 if (observers != null) {
-                    observers.forEach(o -> o.loadFlowConverged(context.getContingency(), violations));
+                    observers.forEach(o -> o.noMoreViolations(context.getContingency()));
                 }
+                return true;
+            }
 
-                // no more violations => work complete
-                if (violations.isEmpty()) {
-                    LOGGER.info("No more violation");
-                    if (observers != null) {
-                        observers.forEach(o -> o.noMoreViolations(context.getContingency()));
-                    }
-                    return true;
-                }
+            Set<String> actionsTaken = new HashSet<>();
+            for (Rule rule : actionDb.getRules()) {
 
-                Set<String> actionsTaken = new HashSet<>();
-                for (Rule rule : actionDb.getRules()) {
-
-                    RuleEvaluationStatus status;
-                    final Map<String, Object> variables;
-                    final Map<String, Boolean> actions;
-                    if (context.getRuleMatchCount(rule.getId()) >= rule.getLife()) {
-                        status = RuleEvaluationStatus.DEAD;
-                        variables = Collections.emptyMap();
-                        actions = Collections.emptyMap();
-                    } else {
-                        // re-evaluate the condition
-                        if (rule.getCondition().getType() != ConditionType.EXPRESSION) {
-                            throw new AssertionError("TODO");
-                        }
-                        ExpressionNode conditionExpr = ((ExpressionCondition) rule.getCondition()).getNode();
-                        EvaluationContext evalContext = new EvaluationContext() {
-                            @Override
-                            public Network getNetwork() {
-                                return context.getNetwork();
-                            }
-
-                            @Override
-                            public Contingency getContingency() {
-                                return context.getContingency();
-                            }
-
-                            @Override
-                            public boolean isActionTaken(String actionId) {
-                                return context.getTimeLine().actionTaken(actionId);
-                            }
-                        };
-                        boolean ok = ExpressionEvaluator.evaluate(conditionExpr, evalContext).equals(Boolean.TRUE);
-
-                        LOGGER.debug("Evaluating {} to {}", ExpressionPrinter.toString(conditionExpr), Boolean.toString(ok));
-
-                        variables = ExpressionVariableLister.list(conditionExpr).stream()
-                            .collect(Collectors.toMap(ExpressionPrinter::toString,
-                                n -> ExpressionEvaluator.evaluate(n, evalContext),
-                                (v1, v2) -> v1,
-                                TreeMap::new));
-
-                        LOGGER.debug("Variables values: {}", variables);
-
-                        if (ok) {
-                            status = RuleEvaluationStatus.TRUE;
-                            context.incrementRuleMatchCount(rule.getId());
-                        } else {
-                            status = RuleEvaluationStatus.FALSE;
-                        }
-
-                        actions = ExpressionActionTakenLister.list(conditionExpr).stream()
-                            .collect(Collectors.toMap(s -> s,
-                                s -> context.getTimeLine().actionTaken(s),
-                                (s1, s2) -> s1,
-                                TreeMap::new));
-                    }
-
-                    if (observers != null) {
-                        observers.forEach(o -> o.ruleChecked(context.getContingency(), rule, status, variables, actions));
-                    }
-
-                    if (status == RuleEvaluationStatus.TRUE) {
-                        for (String actionId : rule.getActions()) {
-                            Action action = actionDb.getAction(actionId);
-
-                            // apply action
-                            LOGGER.info("Apply action '{}'", action.getId());
-                            if (observers != null) {
-                                observers.forEach(o-> o.beforeAction(context.getContingency(), actionId));
-                            }
-
-                            action.run(context.getNetwork(), computationManager);
-
-                            if (observers != null) {
-                                observers.forEach(o-> o.afterAction(context.getContingency(), actionId));
-                            }
-                            actionsTaken.add(actionId);
-                        }
-                    }
-                }
-
-                // record the action in the time line
-                context.getTimeLine().getActions().addAll(actionsTaken);
-
-                if (observers != null) {
-                    observers.forEach(o -> o.roundEnd(context.getContingency(), context.getRound()));
-                }
-
-                if (actionsTaken.size() > 0) {
-                    context.setRound(context.getRound() + 1);
-                    return next(actionDb, context);
+                RuleEvaluationStatus status;
+                final Map<String, Object> variables;
+                final Map<String, Boolean> actions;
+                if (context.getRuleMatchCount(rule.getId()) >= rule.getLife()) {
+                    status = RuleEvaluationStatus.DEAD;
+                    variables = Collections.emptyMap();
+                    actions = Collections.emptyMap();
                 } else {
-                    LOGGER.info("Still some violations and no rule match");
-                    if (observers != null) {
-                        observers.forEach(o -> o.violationsAnymoreAndNoRulesMatch(context.getContingency()));
+                    // re-evaluate the condition
+                    if (rule.getCondition().getType() != ConditionType.EXPRESSION) {
+                        throw new AssertionError("TODO");
                     }
-                    return false;
+                    ExpressionNode conditionExpr = ((ExpressionCondition) rule.getCondition()).getNode();
+                    EvaluationContext evalContext = new EvaluationContext() {
+                        @Override
+                        public Network getNetwork() {
+                            return context.getNetwork();
+                        }
+
+                        @Override
+                        public Contingency getContingency() {
+                            return context.getContingency();
+                        }
+
+                        @Override
+                        public boolean isActionTaken(String actionId) {
+                            return context.getTimeLine().actionTaken(actionId);
+                        }
+                    };
+                    boolean ok = ExpressionEvaluator.evaluate(conditionExpr, evalContext).equals(Boolean.TRUE);
+
+                    LOGGER.debug("Evaluating {} to {}", ExpressionPrinter.toString(conditionExpr), Boolean.toString(ok));
+
+                    variables = ExpressionVariableLister.list(conditionExpr).stream()
+                        .collect(Collectors.toMap(ExpressionPrinter::toString,
+                            n -> ExpressionEvaluator.evaluate(n, evalContext),
+                            (v1, v2) -> v1,
+                            TreeMap::new));
+
+                    LOGGER.debug("Variables values: {}", variables);
+
+                    if (ok) {
+                        status = RuleEvaluationStatus.TRUE;
+                        context.incrementRuleMatchCount(rule.getId());
+                    } else {
+                        status = RuleEvaluationStatus.FALSE;
+                    }
+
+                    actions = ExpressionActionTakenLister.list(conditionExpr).stream()
+                        .collect(Collectors.toMap(s -> s,
+                            s -> context.getTimeLine().actionTaken(s),
+                            (s1, s2) -> s1,
+                            TreeMap::new));
                 }
-            } else {
-                LOGGER.warn("Loadflow diverged: {}", result.getMetrics());
+
                 if (observers != null) {
-                    observers.forEach(o -> o.loadFlowDiverged(context.getContingency()));
+                    observers.forEach(o -> o.ruleChecked(context.getContingency(), rule, status, variables, actions));
+                }
+
+                if (status == RuleEvaluationStatus.TRUE) {
+                    for (String actionId : rule.getActions()) {
+                        Action action = actionDb.getAction(actionId);
+
+                        // apply action
+                        LOGGER.info("Apply action '{}'", action.getId());
+                        if (observers != null) {
+                            observers.forEach(o-> o.beforeAction(context.getContingency(), actionId));
+                        }
+
+                        action.run(context.getNetwork(), computationManager);
+
+                        if (observers != null) {
+                            observers.forEach(o-> o.afterAction(context.getContingency(), actionId));
+                        }
+                        actionsTaken.add(actionId);
+                    }
+                }
+            }
+
+            // record the action in the time line
+            context.getTimeLine().getActions().addAll(actionsTaken);
+
+            if (observers != null) {
+                observers.forEach(o -> o.roundEnd(context.getContingency(), context.getRound()));
+            }
+
+            if (actionsTaken.size() > 0) {
+                context.setRound(context.getRound() + 1);
+                return next(actionDb, context);
+            } else {
+                LOGGER.info("Still some violations and no rule match");
+                if (observers != null) {
+                    observers.forEach(o -> o.violationsAnymoreAndNoRulesMatch(context.getContingency()));
                 }
                 return false;
             }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        } else {
+            LOGGER.warn("Loadflow diverged: {}", result.getMetrics());
+            if (observers != null) {
+                observers.forEach(o -> o.loadFlowDiverged(context.getContingency()));
+            }
+            return false;
         }
     }
 }

--- a/action/action-simulator/src/test/java/eu/itesla_project/action/simulator/AbstractLoadFlowRulesEngineTest.java
+++ b/action/action-simulator/src/test/java/eu/itesla_project/action/simulator/AbstractLoadFlowRulesEngineTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractLoadFlowRulesEngineTest {
         actionDb = new ActionDslLoader(src).load(network);
         engine = new LoadFlowActionSimulator(network, computationManager, new LoadFlowActionSimulatorConfig(LoadFlowFactory.class, 3, false), observer) {
             @Override
-            protected LoadFlowFactory newLoadLoadLowFactory() {
+            protected LoadFlowFactory newLoadFlowFactory() {
                 return loadFlowFactory;
             }
         };

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -39,6 +39,11 @@
     </build>
 
     <dependencies>
+        <!-- Compilation dependencies -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>

--- a/commons/src/main/java/eu/itesla_project/commons/json/JsonUtil.java
+++ b/commons/src/main/java/eu/itesla_project/commons/json/JsonUtil.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2017, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package eu.itesla_project.commons.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.base.Strings;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ */
+public final class JsonUtil {
+
+    private JsonUtil() {
+    }
+
+    public static void writeOptionalStringField(JsonGenerator jsonGenerator, String fieldName, String value) throws IOException {
+        Objects.requireNonNull(jsonGenerator);
+        Objects.requireNonNull(fieldName);
+
+        if (!Strings.isNullOrEmpty(value)) {
+            jsonGenerator.writeStringField(fieldName, value);
+        }
+    }
+
+    public static void writeOptionalEnumField(JsonGenerator jsonGenerator, String fieldName, Enum<?> value) throws IOException {
+        Objects.requireNonNull(jsonGenerator);
+        Objects.requireNonNull(fieldName);
+
+        if (value != null) {
+            jsonGenerator.writeStringField(fieldName, value.name());
+        }
+    }
+
+    public static void writeOptionalFloatField(JsonGenerator jsonGenerator, String fieldName, float value) throws IOException {
+        Objects.requireNonNull(jsonGenerator);
+        Objects.requireNonNull(fieldName);
+
+        if (!Float.isNaN(value)) {
+            jsonGenerator.writeNumberField(fieldName, value);
+        }
+    }
+
+    public static void writeOptionalIntegerField(JsonGenerator jsonGenerator, String fieldName, int value) throws IOException {
+        Objects.requireNonNull(jsonGenerator);
+        Objects.requireNonNull(fieldName);
+
+        if (value != Integer.MAX_VALUE) {
+            jsonGenerator.writeNumberField(fieldName, value);
+        }
+    }
+
+}

--- a/contingency-api/src/main/java/eu/itesla_project/contingency/json/ContingencyElementDeserializer.java
+++ b/contingency-api/src/main/java/eu/itesla_project/contingency/json/ContingencyElementDeserializer.java
@@ -52,6 +52,8 @@ public class ContingencyElementDeserializer extends StdDeserializer<ContingencyE
         if (type != null) {
             switch (type) {
                 case LINE:
+                    return new LineContingency(id, voltageLevelId);
+
                 case BRANCH:
                     return new BranchContingency(id, voltageLevelId);
 

--- a/contingency-api/src/main/java/eu/itesla_project/contingency/json/ContingencyElementSerializer.java
+++ b/contingency-api/src/main/java/eu/itesla_project/contingency/json/ContingencyElementSerializer.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2017, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package eu.itesla_project.contingency.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import eu.itesla_project.commons.json.JsonUtil;
+import eu.itesla_project.contingency.BranchContingency;
+import eu.itesla_project.contingency.ContingencyElement;
+
+import java.io.IOException;
+
+/**
+ * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ */
+public class ContingencyElementSerializer extends StdSerializer<ContingencyElement> {
+
+    public ContingencyElementSerializer() {
+        super(ContingencyElement.class);
+    }
+
+    @Override
+    public void serialize(ContingencyElement contingencyElement, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeStringField("id", contingencyElement.getId());
+        jsonGenerator.writeStringField("type", contingencyElement.getType().name());
+        if (contingencyElement instanceof BranchContingency) {
+            BranchContingency branchContingencyElement = (BranchContingency) contingencyElement;
+            JsonUtil.writeOptionalStringField(jsonGenerator, "voltageLevelId", branchContingencyElement.getVoltageLevelId());
+        }
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/contingency-api/src/test/java/eu/itesla_project/contingency/json/ContingencyJsonTest.java
+++ b/contingency-api/src/test/java/eu/itesla_project/contingency/json/ContingencyJsonTest.java
@@ -23,6 +23,8 @@ public class ContingencyJsonTest extends AbstractConverterTest {
         List<ContingencyElement> elements = new ArrayList<>();
         elements.add(new BranchContingency("NHV1_NHV2_2", "VLHV1"));
         elements.add(new BranchContingency("NHV1_NHV2_1"));
+        elements.add(new LineContingency("NHV1_NHV2_2", "VLHV1"));
+        elements.add(new LineContingency("NHV1_NHV2_2"));
         elements.add(new GeneratorContingency("GEN"));
         elements.add(new BusbarSectionContingency("BBS1"));
 
@@ -51,8 +53,11 @@ public class ContingencyJsonTest extends AbstractConverterTest {
 
         try (OutputStream os = Files.newOutputStream(jsonFile)) {
             ObjectMapper mapper = new ObjectMapper();
-            ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();
+            SimpleModule module = new SimpleModule();
+            module.addSerializer(ContingencyElement.class, new ContingencyElementSerializer());
+            mapper.registerModule(module);
 
+            ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();
             writer.writeValue(os, object);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/contingency-api/src/test/resources/contingency.json
+++ b/contingency-api/src/test/resources/contingency.json
@@ -2,12 +2,18 @@
   "id" : "contingency",
   "elements" : [ {
     "id" : "NHV1_NHV2_2",
-    "voltageLevelId" : "VLHV1",
-    "type" : "BRANCH"
+    "type" : "BRANCH",
+    "voltageLevelId" : "VLHV1"
   }, {
     "id" : "NHV1_NHV2_1",
-    "voltageLevelId" : null,
     "type" : "BRANCH"
+  }, {
+    "id" : "NHV1_NHV2_2",
+    "type" : "LINE",
+    "voltageLevelId" : "VLHV1"
+  }, {
+    "id" : "NHV1_NHV2_2",
+    "type" : "LINE"
   }, {
     "id" : "GEN",
     "type" : "GENERATOR"

--- a/iidm/iidm-api/src/main/java/eu/itesla_project/iidm/network/TwoTerminalsConnectable.java
+++ b/iidm/iidm-api/src/main/java/eu/itesla_project/iidm/network/TwoTerminalsConnectable.java
@@ -40,6 +40,8 @@ public interface TwoTerminalsConnectable<I extends TwoTerminalsConnectable<I>> e
 
     Terminal getTerminal(String voltageLevelId);
 
+    CurrentLimits getCurrentLimits(Side side);
+
     CurrentLimits getCurrentLimits1();
 
     CurrentLimitsAdder newCurrentLimits1();

--- a/iidm/iidm-impl/src/main/java/eu/itesla_project/iidm/network/impl/AbstractBranch.java
+++ b/iidm/iidm-impl/src/main/java/eu/itesla_project/iidm/network/impl/AbstractBranch.java
@@ -75,6 +75,18 @@ abstract class AbstractBranch<I extends Connectable<I>> extends AbstractConnecta
         }
     }
 
+    public CurrentLimits getCurrentLimits(Side side) {
+        switch (side) {
+            case ONE:
+                return limits1;
+            case TWO:
+                return limits2;
+            default:
+                throw new InternalError();
+        }
+
+    }
+
     public CurrentLimits getCurrentLimits1() {
         return limits1;
     }

--- a/iidm/iidm-impl/src/test/java/eu/itesla_project/iidm/network/impl/LineTest.java
+++ b/iidm/iidm-impl/src/test/java/eu/itesla_project/iidm/network/impl/LineTest.java
@@ -111,6 +111,8 @@ public class LineTest {
             .add();
         assertSame(currentLimits1, acLine.getCurrentLimits1());
         assertSame(currentLimits2, acLine.getCurrentLimits2());
+        assertSame(currentLimits1, acLine.getCurrentLimits(Branch.Side.ONE));
+        assertSame(currentLimits2, acLine.getCurrentLimits(Branch.Side.TWO));
 
         // add power on line
         Terminal terminal1 = acLine.getTerminal1();

--- a/iidm/iidm-impl/src/test/java/eu/itesla_project/iidm/network/impl/LineTest.java
+++ b/iidm/iidm-impl/src/test/java/eu/itesla_project/iidm/network/impl/LineTest.java
@@ -6,199 +6,65 @@
  */
 package eu.itesla_project.iidm.network.impl;
 
-import eu.itesla_project.commons.ITeslaException;
 import eu.itesla_project.iidm.network.*;
-import eu.itesla_project.iidm.network.test.NoEquipmentNetworkFactory;
-import org.junit.Before;
-import org.junit.Rule;
+import eu.itesla_project.iidm.network.test.EurostagTutorialExample1Factory;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.*;
 
 public class LineTest {
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    private Network network;
-    private VoltageLevel voltageLevelA;
-    private VoltageLevel voltageLevelB;
-
-    @Before
-    public void setUp() {
-        network = NoEquipmentNetworkFactory.create();
-        voltageLevelA = network.getVoltageLevel("vl1");
-        voltageLevelB = network.getVoltageLevel("vl2");
-    }
-
     @Test
-    public void baseAcLineTests() {
-        // adder
-        Line acLine = network.newLine()
-                                .setId("line")
-                                .setName("lineName")
-                                .setR(1.0f)
-                                .setX(2.0f)
-                                .setG1(3.0f)
-                                .setG2(3.5f)
-                                .setB1(4.0f)
-                                .setB2(4.5f)
-                                .setVoltageLevel1("vl1")
-                                .setVoltageLevel2("vl2")
-                                .setBus1("busA")
-                                .setBus2("busB")
-                                .setConnectableBus1("busA")
-                                .setConnectableBus2("busB")
-                            .add();
-        assertEquals("line", acLine.getId());
-        assertEquals("lineName", acLine.getName());
-        assertEquals(1.0f, acLine.getR(), 0.0f);
-        assertEquals(2.0f, acLine.getX(), 0.0f);
-        assertEquals(3.0f, acLine.getG1(), 0.0f);
-        assertEquals(3.5f, acLine.getG2(), 0.0f);
-        assertEquals(4.0f, acLine.getB1(), 0.0f);
-        assertEquals(4.5f, acLine.getB2(), 0.0f);
-
-        Bus busA = voltageLevelA.getBusBreakerView().getBus("busA");
-        Bus busB = voltageLevelB.getBusBreakerView().getBus("busB");
-        assertSame(busA, acLine.getTerminal1().getBusBreakerView().getBus());
-        assertSame(busB, acLine.getTerminal2().getBusBreakerView().getBus());
-        assertSame(busA, acLine.getTerminal("vl1").getBusBreakerView().getConnectableBus());
-        assertSame(busB, acLine.getTerminal("vl2").getBusBreakerView().getConnectableBus());
-        assertSame(busA, acLine.getTerminal(TwoTerminalsConnectable.Side.ONE).getBusBreakerView().getConnectableBus());
-        assertSame(busB, acLine.getTerminal(TwoTerminalsConnectable.Side.TWO).getBusBreakerView().getConnectableBus());
-
-        assertFalse(acLine.isTieLine());
-        assertEquals(ConnectableType.LINE, acLine.getType());
-
-        // setter getter
+    public void testSetterGetter() {
+        Network network = EurostagTutorialExample1Factory.create();
+        Line line = network.getLine("NHV1_NHV2_1");
         float r = 10.0f;
         float x = 20.0f;
         float g1 = 30.0f;
         float g2 = 35.0f;
         float b1 = 40.0f;
         float b2 = 45.0f;
-        acLine.setR(r);
-        assertEquals(r, acLine.getR(), 0.0f);
-        acLine.setX(x);
-        assertEquals(x, acLine.getX(), 0.0f);
-        acLine.setG1(g1);
-        assertEquals(g1, acLine.getG1(), 0.0f);
-        acLine.setG2(g2);
-        assertEquals(g2, acLine.getG2(), 0.0f);
-        acLine.setB1(b1);
-        assertEquals(b1, acLine.getB1(), 0.0f);
-        acLine.setB2(b2);
-        assertEquals(b2, acLine.getB2(), 0.0f);
-        assertFalse(acLine.isTieLine());
+        float delta = 0.0f;
+        line.setR(r);
+        assertEquals(r, line.getR(), delta);
+        line.setX(x);
+        assertEquals(x, line.getX(), delta);
+        line.setG1(g1);
+        assertEquals(g1, line.getG1(), delta);
+        line.setG2(g2);
+        assertEquals(g2, line.getG2(), delta);
+        line.setB1(b1);
+        assertEquals(b1, line.getB1(), delta);
+        line.setB2(b2);
+        assertEquals(b2, line.getB2(), delta);
+        assertFalse(line.isTieLine());
 
-        CurrentLimits currentLimits1 = acLine.newCurrentLimits1()
-                                                .setPermanentLimit(100)
-                                                .beginTemporaryLimit()
-                                                .setName("5'")
-                                                .setAcceptableDuration(5 * 60)
-                                                .setValue(1400)
-                                                .endTemporaryLimit()
-                                            .add();
-        CurrentLimits currentLimits2 = acLine.newCurrentLimits2()
-                                                .setPermanentLimit(50)
-                                                .beginTemporaryLimit()
-                                                .setName("20'")
-                                                .setAcceptableDuration(20 * 60)
-                                                .setValue(1200)
-                                                .endTemporaryLimit()
-                                            .add();
-        assertSame(currentLimits1, acLine.getCurrentLimits1());
-        assertSame(currentLimits2, acLine.getCurrentLimits2());
-
-        // add power on line
-        Terminal terminal1 = acLine.getTerminal1();
-        terminal1.setP(1.0f);
-        terminal1.setQ((float) Math.sqrt(2.0f));
-        busA.setV(1.0f);
-        // i1 = 1000
-        assertTrue(acLine.checkPermanentLimit(TwoTerminalsConnectable.Side.ONE, 0.9f));
-        assertTrue(acLine.checkPermanentLimit(TwoTerminalsConnectable.Side.ONE));
-        assertTrue(acLine.checkPermanentLimit1());
-        assertNotNull(acLine.checkTemporaryLimits(TwoTerminalsConnectable.Side.ONE, 0.9f));
-        assertNotNull(acLine.checkTemporaryLimits(TwoTerminalsConnectable.Side.ONE));
-
-        Terminal terminal2 = acLine.getTerminal2();
-        terminal2.setP(1.0f);
-        terminal2.setQ((float) Math.sqrt(2.0f));
-        busB.setV(1.0e3f);
-        // i2 = 1
-        assertFalse(acLine.checkPermanentLimit(TwoTerminalsConnectable.Side.TWO, 0.9f));
-        assertFalse(acLine.checkPermanentLimit(TwoTerminalsConnectable.Side.TWO));
-        assertFalse(acLine.checkPermanentLimit2());
-        assertNull(acLine.checkTemporaryLimits(TwoTerminalsConnectable.Side.TWO, 0.9f));
-        assertNull(acLine.checkTemporaryLimits(TwoTerminalsConnectable.Side.TWO));
+        CurrentLimits currentLimits1 = line.newCurrentLimits1()
+                                            .setPermanentLimit(100)
+                                            .beginTemporaryLimit()
+                                            .setName("5'")
+                                            .setAcceptableDuration(5 * 60)
+                                            .setValue(1400)
+                                            .setFictitious(true)
+                                            .endTemporaryLimit()
+                                        .add();
+        CurrentLimits currentLimits2 = line.newCurrentLimits2()
+                                            .setPermanentLimit(50)
+                                            .beginTemporaryLimit()
+                                            .setName("20'")
+                                            .setAcceptableDuration(20 * 60)
+                                            .setValue(1200)
+                                            .endTemporaryLimit()
+                                        .add();
+        assertSame(currentLimits1, line.getCurrentLimits1());
+        assertSame(currentLimits2, line.getCurrentLimits2());
+        assertSame(currentLimits1, line.getCurrentLimits(TwoTerminalsConnectable.Side.ONE));
+        assertSame(currentLimits2, line.getCurrentLimits(TwoTerminalsConnectable.Side.TWO));
     }
 
     @Test
-    public void invalidR() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("r is invalid");
-        createLineBetweenVoltageAB("invalid", "invalid", Float.NaN, 2.0f, 3.0f, 3.5f, 4.0f, 4.5f);
-    }
-
-    @Test
-    public void invalidX() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("x is invalid");
-        createLineBetweenVoltageAB("invalid", "invalid", 1.0f, Float.NaN, 3.0f, 3.5f, 4.0f, 4.5f);
-    }
-
-    @Test
-    public void invalidG1() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("g1 is invalid");
-        createLineBetweenVoltageAB("invalid", "invalid", 1.0f, 2.0f, Float.NaN, 3.5f, 4.0f, 4.5f);
-    }
-
-    @Test
-    public void invalidG2() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("g2 is invalid");
-        createLineBetweenVoltageAB("invalid", "invalid", 1.0f, 2.0f, 3.0f, Float.NaN, 4.0f, 4.5f);
-    }
-
-    @Test
-    public void invalidB1() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("b1 is invalid");
-        createLineBetweenVoltageAB("invalid", "invalid", 1.0f, 2.0f, 3.0f, 3.5f, Float.NaN, 4.5f);
-    }
-
-    @Test
-    public void invalidB2() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("b2 is invalid");
-        createLineBetweenVoltageAB("invalid", "invalid", 1.0f, 2.0f, 3.0f, 3.5f, 4.0f, Float.NaN);
-    }
-
-    @Test
-    public void duplicateAcLine() {
-        createLineBetweenVoltageAB("duplicate", "duplicate", 1.0f, 2.0f, 3.0f, 3.5f, 4.0f, 4.5f);
-        thrown.expect(ITeslaException.class);
-        createLineBetweenVoltageAB("duplicate", "duplicate", 1.0f, 2.0f, 3.0f, 3.5f, 4.0f, 4.5f);
-    }
-
-    @Test
-    public void testRemoveAcLine() {
-        createLineBetweenVoltageAB("toRemove", "toRemove", 1.0f, 2.0f, 3.0f, 3.5f, 4.0f, 4.5f);
-        Line line = network.getLine("toRemove");
-        assertNotNull(line);
-        int count = network.getLineCount();
-        line.remove();
-        assertNotNull(line);
-        assertNull(network.getLine("toRemove"));
-        assertEquals(count - 1, network.getLineCount());
-    }
-
-    @Test
-    public void testTieLineAdder() {
+    public void testTieLineSetterGetter() {
+        Network network = EurostagTutorialExample1Factory.create();
         float r = 10.0f;
         float r2 = 1.0f;
         float x = 20.0f;
@@ -213,16 +79,15 @@ public class LineTest {
         float hl2b2 = 145.0f;
         float xnodeP = 50.0f;
         float xnodeQ = 60.0f;
-
-        // adder
+        float delta = 0.0f;
         TieLine tieLine = network.newTieLine().setId("testTie")
                             .setName("testNameTie")
-                            .setVoltageLevel1("vl1")
-                            .setBus1("busA")
-                            .setConnectableBus1("busA")
-                            .setVoltageLevel2("vl2")
-                            .setBus2("busB")
-                            .setConnectableBus2("busB")
+                            .setVoltageLevel1("VLHV1")
+                            .setBus1("NHV1")
+                            .setConnectableBus1("NHV1")
+                            .setVoltageLevel2("VLHV2")
+                            .setBus2("NHV2")
+                            .setConnectableBus2("NHV2")
                             .setUcteXnodeCode("ucte")
                             .line1()
                                 .setId("hl1")
@@ -247,18 +112,16 @@ public class LineTest {
                                 .setXnodeQ(xnodeQ)
                             .add();
         assertTrue(tieLine.isTieLine());
-        assertEquals(ConnectableType.LINE, tieLine.getType());
         assertEquals("ucte", tieLine.getUcteXnodeCode());
         assertEquals("half1_name", tieLine.getHalf1().getName());
         assertEquals("hl2", tieLine.getHalf2().getId());
-        assertEquals(r + r2, tieLine.getR(), 0.0f);
-        assertEquals(x + x2, tieLine.getX(), 0.0f);
-        assertEquals(hl1g1 + hl2g1, tieLine.getG1(), 0.0f);
-        assertEquals(hl1g2 + hl2g2, tieLine.getG2(), 0.0f);
-        assertEquals(hl1b1 + hl2b1, tieLine.getB1(), 0.0f);
-        assertEquals(hl1b2 + hl2b2, tieLine.getB2(), 0.0f);
+        assertEquals(r + r2, tieLine.getR(), delta);
+        assertEquals(x + x2, tieLine.getX(), delta);
+        assertEquals(hl1g1 + hl2g1, tieLine.getG1(), delta);
+        assertEquals(hl1g2 + hl2g2, tieLine.getG2(), delta);
+        assertEquals(hl1b1 + hl2b1, tieLine.getB1(), delta);
+        assertEquals(hl1b2 + hl2b2, tieLine.getB2(), delta);
 
-        // invalid set line characteristics on tieLine
         try {
             tieLine.setR(1.0f);
             fail();
@@ -296,168 +159,64 @@ public class LineTest {
         }
 
         TieLineImpl.HalfLine half1 = tieLine.getHalf1();
-        assertEquals(xnodeP, half1.getXnodeP(), 0.0f);
-        assertEquals(xnodeQ, half1.getXnodeQ(), 0.0f);
+        assertEquals(xnodeP, half1.getXnodeP(), delta);
+        assertEquals(xnodeQ, half1.getXnodeQ(), delta);
     }
 
     @Test
-    public void invalidHalfLineCharacteristicsR() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("r is not set for half line");
-        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", Float.NaN, 2.0f,
-                3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "code");
-    }
-
-    @Test
-    public void invalidHalfLineCharacteristicsX() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("x is not set for half line");
-        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, Float.NaN,
-                3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "code");
-    }
-
-    @Test
-    public void invalidHalfLineCharacteristicsG1() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("g1 is not set for half line");
-        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
-                Float.NaN, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "code");
-    }
-
-    @Test
-    public void invalidHalfLineCharacteristicsG2() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("g2 is not set for half line");
-        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
-                3.0f, Float.NaN, 4.0f, 4.5f, 5.0f, 6.0f, "code");
-    }
-
-    @Test
-    public void invalidHalfLineCharacteristicsB1() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("b1 is not set for half line");
-        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
-                3.0f, 3.5f, Float.NaN, 4.5f, 5.0f, 6.0f, "code");
-    }
-
-    @Test
-    public void invalidHalfLineCharacteristicsB2() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("b2 is not set for half line");
-        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
-                3.0f, 3.5f, 4.0f, Float.NaN, 5.0f, 6.0f, "code");
-    }
-
-    @Test
-    public void invalidHalfLineCharacteristicsP() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("xnodeP is not set for half line");
-        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
-                3.0f, 3.5f, 4.0f, 4.5f, Float.NaN, 6.0f, "code");
-    }
-
-    @Test
-    public void invalidHalfLineCharacteristicsQ() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("xnodeQ is not set for half line");
-        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
-                3.0f, 3.5f, 4.0f, 4.5f, 5.0f, Float.NaN, "code");
-    }
-
-    @Test
-    public void halfLineIdNull() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("id is not set for half line");
-        createTieLineWithHalfline2ByDefault("invalid", "invalid", null, 1.0f, 2.0f,
-                3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "code");
-    }
-
-    @Test
-    public void uctecodeNull() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("ucteXnodeCode is not set");
-        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
-                3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, null);
-    }
-
-    @Test
-    public void duplicate() {
-        createTieLineWithHalfline2ByDefault("duplicate", "duplicate", "id1", 1.0f, 2.0f,
-                3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "duplicate");
-        thrown.expect(ITeslaException.class);
-        createTieLineWithHalfline2ByDefault("duplicate", "duplicate", "id1", 1.0f, 2.0f,
-                3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "duplicate");
-    }
-
-    @Test
-    public void testRemove() {
-        createTieLineWithHalfline2ByDefault("toRemove", "toRemove", "id1", 1.0f, 2.0f,
-                3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "toRemove");
-        Line line = network.getLine("toRemove");
-        assertNotNull(line);
-        assertTrue(line.isTieLine());
-        int count = network.getLineCount();
-        line.remove();
-        assertNull(network.getLine("toRemove"));
-        assertNotNull(line);
-        assertEquals(count - 1, network.getLineCount());
-    }
-
-    private void createLineBetweenVoltageAB(String id, String name, float r, float x,
-                                            float g1, float g2, float b1, float b2) {
-        network.newLine()
-                    .setId(id)
-                    .setName(name)
-                    .setR(r)
-                    .setX(x)
-                    .setG1(g1)
-                    .setG2(g2)
-                    .setB1(b1)
-                    .setB2(b2)
-                    .setVoltageLevel1("vl1")
-                    .setVoltageLevel2("vl2")
-                    .setBus1("busA")
-                    .setBus2("busB")
-                    .setConnectableBus1("busA")
-                    .setConnectableBus2("busB")
+    public void testDanglingLine() {
+        Network network = EurostagTutorialExample1Factory.create();
+        VoltageLevel vl = network.getVoltageLevel("VLHV1");
+        float r = 10.0f;
+        float x = 20.0f;
+        float g = 30.0f;
+        float b = 40.0f;
+        float p0 = 50.0f;
+        float q0 = 60.0f;
+        float delta = 0.0f;
+        String id = "danglingId";
+        String name = "danlingName";
+        String ucteXnodeCode = "code";
+        DanglingLine danglingLine = vl.newDanglingLine()
+                .setBus("NHV1")
+                .setConnectableBus("NHV1")
+                .setId(id)
+                .setR(r)
+                .setX(x)
+                .setG(g)
+                .setB(b)
+                .setP0(p0)
+                .setQ0(q0)
+                .setName(name)
+                .setUcteXnodeCode(ucteXnodeCode)
                 .add();
-    }
+        assertEquals(r, danglingLine.getR(), delta);
+        assertEquals(x, danglingLine.getX(), delta);
+        assertEquals(g, danglingLine.getG(), delta);
+        assertEquals(b, danglingLine.getB(), delta);
+        assertEquals(p0, danglingLine.getP0(), delta);
+        assertEquals(q0, danglingLine.getQ0(), delta);
+        assertEquals(id, danglingLine.getId());
+        assertEquals(name, danglingLine.getName());
+        assertEquals(ucteXnodeCode, danglingLine.getUcteXnodeCode());
 
-    private void createTieLineWithHalfline2ByDefault(String id, String name, String halfLineId, float r, float x,
-                                               float g1, float g2, float b1, float b2,
-                                               float xnodeP, float xnodeQ, String code) {
-        network.newTieLine()
-                    .setId(id)
-                    .setName(name)
-                    .line1()
-                        .setId(halfLineId)
-                        .setName("half1_name")
-                        .setR(r)
-                        .setX(x)
-                        .setB1(b1)
-                        .setB2(b2)
-                        .setG1(g1)
-                        .setG2(g2)
-                        .setXnodeQ(xnodeQ)
-                        .setXnodeP(xnodeP)
-                    .line2()
-                        .setId("hl2")
-                        .setName("half2_name")
-                        .setR(1.0f)
-                        .setX(2.0f)
-                        .setB1(3.0f)
-                        .setB2(3.5f)
-                        .setG1(4.0f)
-                        .setG2(4.5f)
-                        .setXnodeP(5.0f)
-                        .setXnodeQ(6.0f)
-                    .setVoltageLevel1("vl1")
-                    .setBus1("busA")
-                    .setConnectableBus1("busA")
-                    .setVoltageLevel2("vl2")
-                    .setBus2("busB")
-                    .setConnectableBus2("busB")
-                    .setUcteXnodeCode(code)
-                .add();
+        float r2 = 11.0f;
+        float x2 = 21.0f;
+        float g2 = 31.0f;
+        float b2 = 41.0f;
+        float p02 = 51.0f;
+        float q02 = 61.0f;
+        danglingLine.setR(r2);
+        assertEquals(r2, danglingLine.getR(), delta);
+        danglingLine.setX(x2);
+        assertEquals(x2, danglingLine.getX(), delta);
+        danglingLine.setG(g2);
+        assertEquals(g2, danglingLine.getG(), delta);
+        danglingLine.setB(b2);
+        assertEquals(b2, danglingLine.getB(), delta);
+        danglingLine.setP0(p02);
+        assertEquals(p02, danglingLine.getP0(), delta);
+        danglingLine.setQ0(q02);
+        assertEquals(q02, danglingLine.getQ0(), delta);
     }
 }

--- a/iidm/iidm-impl/src/test/java/eu/itesla_project/iidm/network/impl/LineTest.java
+++ b/iidm/iidm-impl/src/test/java/eu/itesla_project/iidm/network/impl/LineTest.java
@@ -6,65 +6,199 @@
  */
 package eu.itesla_project.iidm.network.impl;
 
+import eu.itesla_project.commons.ITeslaException;
 import eu.itesla_project.iidm.network.*;
-import eu.itesla_project.iidm.network.test.EurostagTutorialExample1Factory;
+import eu.itesla_project.iidm.network.test.NoEquipmentNetworkFactory;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.*;
 
 public class LineTest {
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private Network network;
+    private VoltageLevel voltageLevelA;
+    private VoltageLevel voltageLevelB;
+
+    @Before
+    public void setUp() {
+        network = NoEquipmentNetworkFactory.create();
+        voltageLevelA = network.getVoltageLevel("vl1");
+        voltageLevelB = network.getVoltageLevel("vl2");
+    }
+
     @Test
-    public void testSetterGetter() {
-        Network network = EurostagTutorialExample1Factory.create();
-        Line line = network.getLine("NHV1_NHV2_1");
+    public void baseAcLineTests() {
+        // adder
+        Line acLine = network.newLine()
+            .setId("line")
+            .setName("lineName")
+            .setR(1.0f)
+            .setX(2.0f)
+            .setG1(3.0f)
+            .setG2(3.5f)
+            .setB1(4.0f)
+            .setB2(4.5f)
+            .setVoltageLevel1("vl1")
+            .setVoltageLevel2("vl2")
+            .setBus1("busA")
+            .setBus2("busB")
+            .setConnectableBus1("busA")
+            .setConnectableBus2("busB")
+            .add();
+        assertEquals("line", acLine.getId());
+        assertEquals("lineName", acLine.getName());
+        assertEquals(1.0f, acLine.getR(), 0.0f);
+        assertEquals(2.0f, acLine.getX(), 0.0f);
+        assertEquals(3.0f, acLine.getG1(), 0.0f);
+        assertEquals(3.5f, acLine.getG2(), 0.0f);
+        assertEquals(4.0f, acLine.getB1(), 0.0f);
+        assertEquals(4.5f, acLine.getB2(), 0.0f);
+
+        Bus busA = voltageLevelA.getBusBreakerView().getBus("busA");
+        Bus busB = voltageLevelB.getBusBreakerView().getBus("busB");
+        assertSame(busA, acLine.getTerminal1().getBusBreakerView().getBus());
+        assertSame(busB, acLine.getTerminal2().getBusBreakerView().getBus());
+        assertSame(busA, acLine.getTerminal("vl1").getBusBreakerView().getConnectableBus());
+        assertSame(busB, acLine.getTerminal("vl2").getBusBreakerView().getConnectableBus());
+        assertSame(busA, acLine.getTerminal(TwoTerminalsConnectable.Side.ONE).getBusBreakerView().getConnectableBus());
+        assertSame(busB, acLine.getTerminal(TwoTerminalsConnectable.Side.TWO).getBusBreakerView().getConnectableBus());
+
+        assertFalse(acLine.isTieLine());
+        assertEquals(ConnectableType.LINE, acLine.getType());
+
+        // setter getter
         float r = 10.0f;
         float x = 20.0f;
         float g1 = 30.0f;
         float g2 = 35.0f;
         float b1 = 40.0f;
         float b2 = 45.0f;
-        float delta = 0.0f;
-        line.setR(r);
-        assertEquals(r, line.getR(), delta);
-        line.setX(x);
-        assertEquals(x, line.getX(), delta);
-        line.setG1(g1);
-        assertEquals(g1, line.getG1(), delta);
-        line.setG2(g2);
-        assertEquals(g2, line.getG2(), delta);
-        line.setB1(b1);
-        assertEquals(b1, line.getB1(), delta);
-        line.setB2(b2);
-        assertEquals(b2, line.getB2(), delta);
-        assertFalse(line.isTieLine());
+        acLine.setR(r);
+        assertEquals(r, acLine.getR(), 0.0f);
+        acLine.setX(x);
+        assertEquals(x, acLine.getX(), 0.0f);
+        acLine.setG1(g1);
+        assertEquals(g1, acLine.getG1(), 0.0f);
+        acLine.setG2(g2);
+        assertEquals(g2, acLine.getG2(), 0.0f);
+        acLine.setB1(b1);
+        assertEquals(b1, acLine.getB1(), 0.0f);
+        acLine.setB2(b2);
+        assertEquals(b2, acLine.getB2(), 0.0f);
+        assertFalse(acLine.isTieLine());
 
-        CurrentLimits currentLimits1 = line.newCurrentLimits1()
-                                            .setPermanentLimit(100)
-                                            .beginTemporaryLimit()
-                                            .setName("5'")
-                                            .setAcceptableDuration(5 * 60)
-                                            .setValue(1400)
-                                            .setFictitious(true)
-                                            .endTemporaryLimit()
-                                        .add();
-        CurrentLimits currentLimits2 = line.newCurrentLimits2()
-                                            .setPermanentLimit(50)
-                                            .beginTemporaryLimit()
-                                            .setName("20'")
-                                            .setAcceptableDuration(20 * 60)
-                                            .setValue(1200)
-                                            .endTemporaryLimit()
-                                        .add();
-        assertSame(currentLimits1, line.getCurrentLimits1());
-        assertSame(currentLimits2, line.getCurrentLimits2());
-        assertSame(currentLimits1, line.getCurrentLimits(TwoTerminalsConnectable.Side.ONE));
-        assertSame(currentLimits2, line.getCurrentLimits(TwoTerminalsConnectable.Side.TWO));
+        CurrentLimits currentLimits1 = acLine.newCurrentLimits1()
+            .setPermanentLimit(100)
+            .beginTemporaryLimit()
+            .setName("5'")
+            .setAcceptableDuration(5 * 60)
+            .setValue(1400)
+            .endTemporaryLimit()
+            .add();
+        CurrentLimits currentLimits2 = acLine.newCurrentLimits2()
+            .setPermanentLimit(50)
+            .beginTemporaryLimit()
+            .setName("20'")
+            .setAcceptableDuration(20 * 60)
+            .setValue(1200)
+            .endTemporaryLimit()
+            .add();
+        assertSame(currentLimits1, acLine.getCurrentLimits1());
+        assertSame(currentLimits2, acLine.getCurrentLimits2());
+
+        // add power on line
+        Terminal terminal1 = acLine.getTerminal1();
+        terminal1.setP(1.0f);
+        terminal1.setQ((float) Math.sqrt(2.0f));
+        busA.setV(1.0f);
+        // i1 = 1000
+        assertTrue(acLine.checkPermanentLimit(TwoTerminalsConnectable.Side.ONE, 0.9f));
+        assertTrue(acLine.checkPermanentLimit(TwoTerminalsConnectable.Side.ONE));
+        assertTrue(acLine.checkPermanentLimit1());
+        assertNotNull(acLine.checkTemporaryLimits(TwoTerminalsConnectable.Side.ONE, 0.9f));
+        assertNotNull(acLine.checkTemporaryLimits(TwoTerminalsConnectable.Side.ONE));
+
+        Terminal terminal2 = acLine.getTerminal2();
+        terminal2.setP(1.0f);
+        terminal2.setQ((float) Math.sqrt(2.0f));
+        busB.setV(1.0e3f);
+        // i2 = 1
+        assertFalse(acLine.checkPermanentLimit(TwoTerminalsConnectable.Side.TWO, 0.9f));
+        assertFalse(acLine.checkPermanentLimit(TwoTerminalsConnectable.Side.TWO));
+        assertFalse(acLine.checkPermanentLimit2());
+        assertNull(acLine.checkTemporaryLimits(TwoTerminalsConnectable.Side.TWO, 0.9f));
+        assertNull(acLine.checkTemporaryLimits(TwoTerminalsConnectable.Side.TWO));
     }
 
     @Test
-    public void testTieLineSetterGetter() {
-        Network network = EurostagTutorialExample1Factory.create();
+    public void invalidR() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("r is invalid");
+        createLineBetweenVoltageAB("invalid", "invalid", Float.NaN, 2.0f, 3.0f, 3.5f, 4.0f, 4.5f);
+    }
+
+    @Test
+    public void invalidX() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("x is invalid");
+        createLineBetweenVoltageAB("invalid", "invalid", 1.0f, Float.NaN, 3.0f, 3.5f, 4.0f, 4.5f);
+    }
+
+    @Test
+    public void invalidG1() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("g1 is invalid");
+        createLineBetweenVoltageAB("invalid", "invalid", 1.0f, 2.0f, Float.NaN, 3.5f, 4.0f, 4.5f);
+    }
+
+    @Test
+    public void invalidG2() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("g2 is invalid");
+        createLineBetweenVoltageAB("invalid", "invalid", 1.0f, 2.0f, 3.0f, Float.NaN, 4.0f, 4.5f);
+    }
+
+    @Test
+    public void invalidB1() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("b1 is invalid");
+        createLineBetweenVoltageAB("invalid", "invalid", 1.0f, 2.0f, 3.0f, 3.5f, Float.NaN, 4.5f);
+    }
+
+    @Test
+    public void invalidB2() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("b2 is invalid");
+        createLineBetweenVoltageAB("invalid", "invalid", 1.0f, 2.0f, 3.0f, 3.5f, 4.0f, Float.NaN);
+    }
+
+    @Test
+    public void duplicateAcLine() {
+        createLineBetweenVoltageAB("duplicate", "duplicate", 1.0f, 2.0f, 3.0f, 3.5f, 4.0f, 4.5f);
+        thrown.expect(ITeslaException.class);
+        createLineBetweenVoltageAB("duplicate", "duplicate", 1.0f, 2.0f, 3.0f, 3.5f, 4.0f, 4.5f);
+    }
+
+    @Test
+    public void testRemoveAcLine() {
+        createLineBetweenVoltageAB("toRemove", "toRemove", 1.0f, 2.0f, 3.0f, 3.5f, 4.0f, 4.5f);
+        Line line = network.getLine("toRemove");
+        assertNotNull(line);
+        int count = network.getLineCount();
+        line.remove();
+        assertNotNull(line);
+        assertNull(network.getLine("toRemove"));
+        assertEquals(count - 1, network.getLineCount());
+    }
+
+    @Test
+    public void testTieLineAdder() {
         float r = 10.0f;
         float r2 = 1.0f;
         float x = 20.0f;
@@ -79,49 +213,52 @@ public class LineTest {
         float hl2b2 = 145.0f;
         float xnodeP = 50.0f;
         float xnodeQ = 60.0f;
-        float delta = 0.0f;
+
+        // adder
         TieLine tieLine = network.newTieLine().setId("testTie")
-                            .setName("testNameTie")
-                            .setVoltageLevel1("VLHV1")
-                            .setBus1("NHV1")
-                            .setConnectableBus1("NHV1")
-                            .setVoltageLevel2("VLHV2")
-                            .setBus2("NHV2")
-                            .setConnectableBus2("NHV2")
-                            .setUcteXnodeCode("ucte")
-                            .line1()
-                                .setId("hl1")
-                                .setName("half1_name")
-                                .setR(r)
-                                .setX(x)
-                                .setB1(hl1b1)
-                                .setB2(hl1b2)
-                                .setG1(hl1g1)
-                                .setG2(hl1g2)
-                                .setXnodeQ(xnodeQ)
-                                .setXnodeP(xnodeP)
-                            .line2()
-                                .setId("hl2")
-                                .setR(r2)
-                                .setX(x2)
-                                .setB1(hl2b1)
-                                .setB2(hl2b2)
-                                .setG1(hl2g1)
-                                .setG2(hl2g2)
-                                .setXnodeP(xnodeP)
-                                .setXnodeQ(xnodeQ)
-                            .add();
+            .setName("testNameTie")
+            .setVoltageLevel1("vl1")
+            .setBus1("busA")
+            .setConnectableBus1("busA")
+            .setVoltageLevel2("vl2")
+            .setBus2("busB")
+            .setConnectableBus2("busB")
+            .setUcteXnodeCode("ucte")
+            .line1()
+            .setId("hl1")
+            .setName("half1_name")
+            .setR(r)
+            .setX(x)
+            .setB1(hl1b1)
+            .setB2(hl1b2)
+            .setG1(hl1g1)
+            .setG2(hl1g2)
+            .setXnodeQ(xnodeQ)
+            .setXnodeP(xnodeP)
+            .line2()
+            .setId("hl2")
+            .setR(r2)
+            .setX(x2)
+            .setB1(hl2b1)
+            .setB2(hl2b2)
+            .setG1(hl2g1)
+            .setG2(hl2g2)
+            .setXnodeP(xnodeP)
+            .setXnodeQ(xnodeQ)
+            .add();
         assertTrue(tieLine.isTieLine());
+        assertEquals(ConnectableType.LINE, tieLine.getType());
         assertEquals("ucte", tieLine.getUcteXnodeCode());
         assertEquals("half1_name", tieLine.getHalf1().getName());
         assertEquals("hl2", tieLine.getHalf2().getId());
-        assertEquals(r + r2, tieLine.getR(), delta);
-        assertEquals(x + x2, tieLine.getX(), delta);
-        assertEquals(hl1g1 + hl2g1, tieLine.getG1(), delta);
-        assertEquals(hl1g2 + hl2g2, tieLine.getG2(), delta);
-        assertEquals(hl1b1 + hl2b1, tieLine.getB1(), delta);
-        assertEquals(hl1b2 + hl2b2, tieLine.getB2(), delta);
+        assertEquals(r + r2, tieLine.getR(), 0.0f);
+        assertEquals(x + x2, tieLine.getX(), 0.0f);
+        assertEquals(hl1g1 + hl2g1, tieLine.getG1(), 0.0f);
+        assertEquals(hl1g2 + hl2g2, tieLine.getG2(), 0.0f);
+        assertEquals(hl1b1 + hl2b1, tieLine.getB1(), 0.0f);
+        assertEquals(hl1b2 + hl2b2, tieLine.getB2(), 0.0f);
 
+        // invalid set line characteristics on tieLine
         try {
             tieLine.setR(1.0f);
             fail();
@@ -159,64 +296,168 @@ public class LineTest {
         }
 
         TieLineImpl.HalfLine half1 = tieLine.getHalf1();
-        assertEquals(xnodeP, half1.getXnodeP(), delta);
-        assertEquals(xnodeQ, half1.getXnodeQ(), delta);
+        assertEquals(xnodeP, half1.getXnodeP(), 0.0f);
+        assertEquals(xnodeQ, half1.getXnodeQ(), 0.0f);
     }
 
     @Test
-    public void testDanglingLine() {
-        Network network = EurostagTutorialExample1Factory.create();
-        VoltageLevel vl = network.getVoltageLevel("VLHV1");
-        float r = 10.0f;
-        float x = 20.0f;
-        float g = 30.0f;
-        float b = 40.0f;
-        float p0 = 50.0f;
-        float q0 = 60.0f;
-        float delta = 0.0f;
-        String id = "danglingId";
-        String name = "danlingName";
-        String ucteXnodeCode = "code";
-        DanglingLine danglingLine = vl.newDanglingLine()
-                .setBus("NHV1")
-                .setConnectableBus("NHV1")
-                .setId(id)
-                .setR(r)
-                .setX(x)
-                .setG(g)
-                .setB(b)
-                .setP0(p0)
-                .setQ0(q0)
-                .setName(name)
-                .setUcteXnodeCode(ucteXnodeCode)
-                .add();
-        assertEquals(r, danglingLine.getR(), delta);
-        assertEquals(x, danglingLine.getX(), delta);
-        assertEquals(g, danglingLine.getG(), delta);
-        assertEquals(b, danglingLine.getB(), delta);
-        assertEquals(p0, danglingLine.getP0(), delta);
-        assertEquals(q0, danglingLine.getQ0(), delta);
-        assertEquals(id, danglingLine.getId());
-        assertEquals(name, danglingLine.getName());
-        assertEquals(ucteXnodeCode, danglingLine.getUcteXnodeCode());
+    public void invalidHalfLineCharacteristicsR() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("r is not set for half line");
+        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", Float.NaN, 2.0f,
+            3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "code");
+    }
 
-        float r2 = 11.0f;
-        float x2 = 21.0f;
-        float g2 = 31.0f;
-        float b2 = 41.0f;
-        float p02 = 51.0f;
-        float q02 = 61.0f;
-        danglingLine.setR(r2);
-        assertEquals(r2, danglingLine.getR(), delta);
-        danglingLine.setX(x2);
-        assertEquals(x2, danglingLine.getX(), delta);
-        danglingLine.setG(g2);
-        assertEquals(g2, danglingLine.getG(), delta);
-        danglingLine.setB(b2);
-        assertEquals(b2, danglingLine.getB(), delta);
-        danglingLine.setP0(p02);
-        assertEquals(p02, danglingLine.getP0(), delta);
-        danglingLine.setQ0(q02);
-        assertEquals(q02, danglingLine.getQ0(), delta);
+    @Test
+    public void invalidHalfLineCharacteristicsX() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("x is not set for half line");
+        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, Float.NaN,
+            3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "code");
+    }
+
+    @Test
+    public void invalidHalfLineCharacteristicsG1() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("g1 is not set for half line");
+        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
+            Float.NaN, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "code");
+    }
+
+    @Test
+    public void invalidHalfLineCharacteristicsG2() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("g2 is not set for half line");
+        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
+            3.0f, Float.NaN, 4.0f, 4.5f, 5.0f, 6.0f, "code");
+    }
+
+    @Test
+    public void invalidHalfLineCharacteristicsB1() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("b1 is not set for half line");
+        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
+            3.0f, 3.5f, Float.NaN, 4.5f, 5.0f, 6.0f, "code");
+    }
+
+    @Test
+    public void invalidHalfLineCharacteristicsB2() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("b2 is not set for half line");
+        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
+            3.0f, 3.5f, 4.0f, Float.NaN, 5.0f, 6.0f, "code");
+    }
+
+    @Test
+    public void invalidHalfLineCharacteristicsP() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("xnodeP is not set for half line");
+        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
+            3.0f, 3.5f, 4.0f, 4.5f, Float.NaN, 6.0f, "code");
+    }
+
+    @Test
+    public void invalidHalfLineCharacteristicsQ() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("xnodeQ is not set for half line");
+        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
+            3.0f, 3.5f, 4.0f, 4.5f, 5.0f, Float.NaN, "code");
+    }
+
+    @Test
+    public void halfLineIdNull() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("id is not set for half line");
+        createTieLineWithHalfline2ByDefault("invalid", "invalid", null, 1.0f, 2.0f,
+            3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "code");
+    }
+
+    @Test
+    public void uctecodeNull() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("ucteXnodeCode is not set");
+        createTieLineWithHalfline2ByDefault("invalid", "invalid", "invalid", 1.0f, 2.0f,
+            3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, null);
+    }
+
+    @Test
+    public void duplicate() {
+        createTieLineWithHalfline2ByDefault("duplicate", "duplicate", "id1", 1.0f, 2.0f,
+            3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "duplicate");
+        thrown.expect(ITeslaException.class);
+        createTieLineWithHalfline2ByDefault("duplicate", "duplicate", "id1", 1.0f, 2.0f,
+            3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "duplicate");
+    }
+
+    @Test
+    public void testRemove() {
+        createTieLineWithHalfline2ByDefault("toRemove", "toRemove", "id1", 1.0f, 2.0f,
+            3.0f, 3.5f, 4.0f, 4.5f, 5.0f, 6.0f, "toRemove");
+        Line line = network.getLine("toRemove");
+        assertNotNull(line);
+        assertTrue(line.isTieLine());
+        int count = network.getLineCount();
+        line.remove();
+        assertNull(network.getLine("toRemove"));
+        assertNotNull(line);
+        assertEquals(count - 1, network.getLineCount());
+    }
+
+    private void createLineBetweenVoltageAB(String id, String name, float r, float x,
+                                            float g1, float g2, float b1, float b2) {
+        network.newLine()
+            .setId(id)
+            .setName(name)
+            .setR(r)
+            .setX(x)
+            .setG1(g1)
+            .setG2(g2)
+            .setB1(b1)
+            .setB2(b2)
+            .setVoltageLevel1("vl1")
+            .setVoltageLevel2("vl2")
+            .setBus1("busA")
+            .setBus2("busB")
+            .setConnectableBus1("busA")
+            .setConnectableBus2("busB")
+            .add();
+    }
+
+    private void createTieLineWithHalfline2ByDefault(String id, String name, String halfLineId, float r, float x,
+                                                     float g1, float g2, float b1, float b2,
+                                                     float xnodeP, float xnodeQ, String code) {
+        network.newTieLine()
+            .setId(id)
+            .setName(name)
+            .line1()
+            .setId(halfLineId)
+            .setName("half1_name")
+            .setR(r)
+            .setX(x)
+            .setB1(b1)
+            .setB2(b2)
+            .setG1(g1)
+            .setG2(g2)
+            .setXnodeQ(xnodeQ)
+            .setXnodeP(xnodeP)
+            .line2()
+            .setId("hl2")
+            .setName("half2_name")
+            .setR(1.0f)
+            .setX(2.0f)
+            .setB1(3.0f)
+            .setB2(3.5f)
+            .setG1(4.0f)
+            .setG2(4.5f)
+            .setXnodeP(5.0f)
+            .setXnodeQ(6.0f)
+            .setVoltageLevel1("vl1")
+            .setBus1("busA")
+            .setConnectableBus1("busA")
+            .setVoltageLevel2("vl2")
+            .setBus2("busB")
+            .setConnectableBus2("busB")
+            .setUcteXnodeCode(code)
+            .add();
     }
 }

--- a/security-analysis/src/main/java/eu/itesla_project/security/LimitViolation.java
+++ b/security-analysis/src/main/java/eu/itesla_project/security/LimitViolation.java
@@ -7,9 +7,9 @@
  */
 package eu.itesla_project.security;
 
-import java.util.Objects;
-
 import eu.itesla_project.iidm.network.Country;
+
+import java.util.Objects;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>

--- a/security-analysis/src/main/java/eu/itesla_project/security/LimitViolationFilter.java
+++ b/security-analysis/src/main/java/eu/itesla_project/security/LimitViolationFilter.java
@@ -7,13 +7,13 @@
  */
 package eu.itesla_project.security;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import eu.itesla_project.commons.config.ModuleConfig;
 import eu.itesla_project.commons.config.PlatformConfig;
 import eu.itesla_project.iidm.network.Country;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>

--- a/security-analysis/src/main/java/eu/itesla_project/security/Security.java
+++ b/security-analysis/src/main/java/eu/itesla_project/security/Security.java
@@ -36,97 +36,79 @@ public final class Security {
     private Security() {
     }
 
-    private static Country getCountry(Branch branch, Terminal terminal) {
-        return terminal == branch.getTerminal1() ? branch.getTerminal1().getVoltageLevel().getSubstation().getCountry()
-                                                 : branch.getTerminal2().getVoltageLevel().getSubstation().getCountry();
+    private static Country getCountry(Branch branch, Branch.Side side) {
+        return branch.getTerminal(side).getVoltageLevel().getSubstation().getCountry();
     }
 
-    private static float getBaseVoltage(Branch branch) {
+    private static float getNominalVoltage(Branch branch) {
         return Math.max(branch.getTerminal1().getVoltageLevel().getNominalV(),
                         branch.getTerminal2().getVoltageLevel().getNominalV());
     }
 
-    private static void checkCurrentLimits(Iterable<? extends Branch> branches, CurrentLimitType currentLimitType,
+    private static float getNominalVoltage(Branch branch, Branch.Side side) {
+        return branch.getTerminal(side).getVoltageLevel().getNominalV();
+    }
+
+    private static String getLimitName(Branch.Overload overload) {
+        int acceptableDuration = overload.getTemporaryLimit().getAcceptableDuration();
+        if (acceptableDuration == Integer.MAX_VALUE) {
+            return PERMANENT_LIMIT_NAME;
+        } else {
+            return String.format("Overload %d'", acceptableDuration / 60);
+        }
+    }
+
+    private static void checkPermanentLimit(Branch branch, Branch.Side side, float limitReduction, List<LimitViolation> violations) {
+        if (branch.checkPermanentLimit(side, limitReduction)) {
+            violations.add(new LimitViolation(branch.getId(),
+                LimitViolationType.CURRENT,
+                branch.getCurrentLimits(side).getPermanentLimit(),
+                PERMANENT_LIMIT_NAME,
+                limitReduction,
+                branch.getTerminal(side).getI(),
+                getCountry(branch, side),
+                getNominalVoltage(branch, side)));
+        }
+    }
+
+    private static void checkCurrentLimits(Branch branch, Branch.Side side, float limitReduction, List<LimitViolation> violations) {
+        Branch.Overload o1 = branch.checkTemporaryLimits(side, limitReduction);
+        if (o1 != null) {
+            violations.add(new LimitViolation(branch.getId(),
+                LimitViolationType.CURRENT,
+                o1.getPreviousLimit(),
+                getLimitName(o1),
+                limitReduction,
+                branch.getTerminal(side).getI(),
+                getCountry(branch, side),
+                getNominalVoltage(branch, side)));
+        } else {
+            checkPermanentLimit(branch, side, limitReduction, violations);
+        }
+    }
+
+    private static void checkCurrentLimits(Iterable<? extends Branch> branches,
                                            float limitReduction, List<LimitViolation> violations) {
         for (Branch branch : branches) {
-            switch (currentLimitType) {
-                case PATL:
-                    if (branch.checkPermanentLimit1(limitReduction)) {
-                        violations.add(new LimitViolation(branch.getId(),
-                                                          LimitViolationType.CURRENT,
-                                                          branch.getCurrentLimits1().getPermanentLimit(),
-                                                          PERMANENT_LIMIT_NAME,
-                                                          limitReduction,
-                                                          branch.getTerminal1().getI(),
-                                                          getCountry(branch, branch.getTerminal1()),
-                                                          getBaseVoltage(branch)));
-                    }
-                    if (branch.checkPermanentLimit2(limitReduction)) {
-                        violations.add(new LimitViolation(branch.getId(),
-                                                          LimitViolationType.CURRENT,
-                                                          branch.getCurrentLimits2().getPermanentLimit(),
-                                                          PERMANENT_LIMIT_NAME,
-                                                          limitReduction,
-                                                          branch.getTerminal2().getI(),
-                                                          getCountry(branch, branch.getTerminal2()),
-                                                          getBaseVoltage(branch)));
-                    }
-                    break;
-
-                case TATL:
-                    Branch.Overload o1 = branch.checkTemporaryLimits1(limitReduction);
-                    if (o1 != null) {
-                        violations.add(new LimitViolation(branch.getId(),
-                                                          LimitViolationType.CURRENT,
-                                                          o1.getPreviousLimit(),
-                                                          o1.getTemporaryLimit().getName(),
-                                                          limitReduction,
-                                                          branch.getTerminal1().getI(),
-                                                          getCountry(branch, branch.getTerminal1()),
-                                                          getBaseVoltage(branch)));
-                    }
-                    Branch.Overload o2 = branch.checkTemporaryLimits2(limitReduction);
-                    if (o2 != null) {
-                        violations.add(new LimitViolation(branch.getId(),
-                                                          LimitViolationType.CURRENT,
-                                                          o2.getPreviousLimit(),
-                                                          o2.getTemporaryLimit().getName(),
-                                                          limitReduction,
-                                                          branch.getTerminal2().getI(),
-                                                          getCountry(branch, branch.getTerminal2()),
-                                                          getBaseVoltage(branch)));
-                    }
-                    break;
-
-                default:
-                    throw new AssertionError();
-            }
+            checkCurrentLimits(branch, Branch.Side.ONE, limitReduction, violations);
+            checkCurrentLimits(branch, Branch.Side.TWO, limitReduction, violations);
         }
     }
 
     public static List<LimitViolation> checkLimits(Network network) {
-        return checkLimits(network, CurrentLimitType.PATL, 1f);
+        return checkLimits(network, 1f);
     }
 
     public static List<LimitViolation> checkLimits(Network network, float limitReduction) {
-        List<LimitViolation> violations = new ArrayList<>();
-        for (CurrentLimitType type : CurrentLimitType.values()) {
-            violations.addAll(checkLimits(network, type, limitReduction));
-        }
-        return violations;
-    }
-
-    public static List<LimitViolation> checkLimits(Network network, CurrentLimitType currentLimitType, float limitReduction) {
         Objects.requireNonNull(network);
-        Objects.requireNonNull(currentLimitType);
         //if (limitReduction <= 0 || limitReduction > 1) {
         // allow to increase the limits
         if (limitReduction <= 0) {
             throw new IllegalArgumentException("Bad limit reduction " + limitReduction);
         }
         List<LimitViolation> violations = new ArrayList<>();
-        checkCurrentLimits(network.getLines(), currentLimitType, limitReduction, violations);
-        checkCurrentLimits(network.getTwoWindingsTransformers(), currentLimitType, limitReduction, violations);
+        checkCurrentLimits(network.getLines(), limitReduction, violations);
+        checkCurrentLimits(network.getTwoWindingsTransformers(), limitReduction, violations);
         for (VoltageLevel vl : network.getVoltageLevels()) {
             if (!Float.isNaN(vl.getLowVoltageLimit())) {
                 for (Bus b : vl.getBusView().getBuses()) {
@@ -169,27 +151,27 @@ public final class Security {
         Objects.requireNonNull(filter);
         List<LimitViolation> filteredViolations = filter.apply(violations);
         if (filteredViolations.size() > 0) {
-            Collections.sort(filteredViolations, (o1, o2) -> o1.getSubjectId().compareTo(o2.getSubjectId()));
+            filteredViolations.sort(Comparator.comparing(LimitViolation::getSubjectId));
             Table table = new Table(9, BorderStyle.CLASSIC_WIDE);
             table.addCell("Country");
             table.addCell("Base voltage");
             table.addCell("Equipment (" + filteredViolations.size() + ")");
             table.addCell("Violation type");
             table.addCell("Violation name");
-            table.addCell("value");
-            table.addCell("limit");
+            table.addCell("Value");
+            table.addCell("Limit");
             table.addCell("abs(value-limit)");
-            table.addCell("charge %");
+            table.addCell("Loading rate %");
             for (LimitViolation violation : filteredViolations) {
                 table.addCell(violation.getCountry() != null ? violation.getCountry().name() : "");
                 table.addCell(Float.isNaN(violation.getBaseVoltage()) ? "" : Float.toString(violation.getBaseVoltage()));
                 table.addCell(violation.getSubjectId());
                 table.addCell(violation.getLimitType().name());
-                table.addCell(Objects.toString(violation.getLimitName(), ""));
+                table.addCell(getViolationName(violation));
                 table.addCell(Float.toString(violation.getValue()));
-                table.addCell(Float.toString(violation.getLimit()) + (violation.getLimitReduction() != 1f ? " * " + violation.getLimitReduction() : ""));
+                table.addCell(getViolationLimit(violation));
                 table.addCell(Float.toString(Math.abs(violation.getValue() - violation.getLimit() * violation.getLimitReduction())));
-                table.addCell(Integer.toString(Math.round(Math.abs(violation.getValue()) / violation.getLimit() * 100f)));
+                table.addCell(Integer.toString(getViolationValue(violation)));
             }
             return table.render();
         }
@@ -215,7 +197,7 @@ public final class Security {
                 new Column("Violation name"),
                 new Column("Value"),
                 new Column("Limit"),
-                new Column("Charge %"))) {
+                new Column("Loading rate %"))) {
             for (String action : result.getPreContingencyResult().getActionsTaken()) {
                 formatter.writeCell(action)
                         .writeEmptyCell()
@@ -229,16 +211,16 @@ public final class Security {
                     ? limitViolationFilter.apply(result.getPreContingencyResult().getLimitViolations())
                     : result.getPreContingencyResult().getLimitViolations();
             filteredLimitViolations.stream()
-                    .sorted((o1, o2) -> o1.getSubjectId().compareTo(o2.getSubjectId()))
+                    .sorted(Comparator.comparing(LimitViolation::getSubjectId))
                     .forEach(violation -> {
                         try {
                             formatter.writeEmptyCell()
                                     .writeCell(violation.getSubjectId())
                                     .writeCell(violation.getLimitType().name())
-                                    .writeCell(Objects.toString(violation.getLimitName(), ""))
+                                    .writeCell(getViolationName(violation))
                                     .writeCell(violation.getValue())
-                                    .writeCell(Float.toString(violation.getLimit()) + (violation.getLimitReduction() != 1f ? " * " + violation.getLimitReduction() : ""))
-                                    .writeCell(Math.round(Math.abs(violation.getValue()) / violation.getLimit() * 100f));
+                                    .writeCell(getViolationLimit(violation))
+                                    .writeCell(getViolationValue(violation));
                         } catch (IOException e) {
                             throw new UncheckedIOException(e);
                         }
@@ -246,6 +228,18 @@ public final class Security {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private static String getViolationName(LimitViolation violation) {
+        return Objects.toString(violation.getLimitName(), "");
+    }
+
+    private static String getViolationLimit(LimitViolation violation) {
+        return Float.toString(violation.getLimit()) + (violation.getLimitReduction() != 1f ? " * " + violation.getLimitReduction() : "");
+    }
+
+    private static int getViolationValue(LimitViolation violation) {
+        return Math.round(Math.abs(violation.getValue()) / violation.getLimit() * 100f);
     }
 
     /**
@@ -316,7 +310,7 @@ public final class Security {
                     new Column("Violation name"),
                     new Column("Value"),
                     new Column("Limit"),
-                    new Column("Charge %"))) {
+                    new Column("Loading rate %"))) {
                 result.getPostContingencyResults()
                         .stream()
                         .sorted(Comparator.comparing(o2 -> o2.getContingency().getId()))
@@ -324,8 +318,8 @@ public final class Security {
                             try {
                                 // configured filtering
                                 List<LimitViolation> filteredLimitViolations = limitViolationFilter != null
-                                        ? limitViolationFilter.apply(postContingencyResult.getLimitViolations())
-                                        : postContingencyResult.getLimitViolations();
+                                        ? limitViolationFilter.apply(postContingencyResult.getLimitViolationsResult().getLimitViolations())
+                                        : postContingencyResult.getLimitViolationsResult().getLimitViolations();
 
                                 // pre-contingency violations filtering
                                 List<LimitViolation> filteredLimitViolations2 = filteredLimitViolations.stream()
@@ -356,7 +350,7 @@ public final class Security {
                                     }
 
                                     filteredLimitViolations2.stream()
-                                            .sorted(Comparator.comparing(o -> o.getSubjectId()))
+                                            .sorted(Comparator.comparing(LimitViolation::getSubjectId))
                                             .forEach(violation -> {
                                                 try {
                                                     formatter.writeEmptyCell()
@@ -364,10 +358,10 @@ public final class Security {
                                                             .writeEmptyCell()
                                                             .writeCell(violation.getSubjectId())
                                                             .writeCell(violation.getLimitType().name())
-                                                            .writeCell(Objects.toString(violation.getLimitName(), ""))
+                                                            .writeCell(getViolationName(violation))
                                                             .writeCell(violation.getValue())
-                                                            .writeCell(Float.toString(violation.getLimit()) + (violation.getLimitReduction() != 1f ? " * " + violation.getLimitReduction() : ""))
-                                                            .writeCell(Math.round(Math.abs(violation.getValue()) / violation.getLimit() * 100f));
+                                                            .writeCell(getViolationLimit(violation))
+                                                            .writeCell(getViolationValue(violation));
                                                 } catch (IOException e) {
                                                     throw new UncheckedIOException(e);
                                                 }

--- a/security-analysis/src/main/java/eu/itesla_project/security/Security.java
+++ b/security-analysis/src/main/java/eu/itesla_project/security/Security.java
@@ -49,8 +49,7 @@ public final class Security {
         return branch.getTerminal(side).getVoltageLevel().getNominalV();
     }
 
-    private static String getLimitName(Branch.Overload overload) {
-        int acceptableDuration = overload.getTemporaryLimit().getAcceptableDuration();
+    public static String getLimitName(int acceptableDuration) {
         if (acceptableDuration == Integer.MAX_VALUE) {
             return PERMANENT_LIMIT_NAME;
         } else {
@@ -77,7 +76,7 @@ public final class Security {
             violations.add(new LimitViolation(branch.getId(),
                 LimitViolationType.CURRENT,
                 o1.getPreviousLimit(),
-                getLimitName(o1),
+                getLimitName(o1.getTemporaryLimit().getAcceptableDuration()),
                 limitReduction,
                 branch.getTerminal(side).getI(),
                 getCountry(branch, side),

--- a/security-analysis/src/main/java/eu/itesla_project/security/SecurityAnalysisImpl.java
+++ b/security-analysis/src/main/java/eu/itesla_project/security/SecurityAnalysisImpl.java
@@ -41,7 +41,7 @@ public class SecurityAnalysisImpl implements SecurityAnalysis {
     }
 
     private static List<LimitViolation> checkLimits(Network network) {
-        return Security.checkLimits(network, Security.CurrentLimitType.TATL, 1f);
+        return Security.checkLimits(network, 1f);
     }
 
     @Override

--- a/security-analysis/src/main/java/eu/itesla_project/security/SecurityAnalysisTool.java
+++ b/security-analysis/src/main/java/eu/itesla_project/security/SecurityAnalysisTool.java
@@ -6,6 +6,19 @@
  */
 package eu.itesla_project.security;
 
+import com.google.auto.service.AutoService;
+import eu.itesla_project.commons.io.table.AsciiTableFormatterFactory;
+import eu.itesla_project.commons.io.table.CsvTableFormatterFactory;
+import eu.itesla_project.commons.tools.Command;
+import eu.itesla_project.commons.tools.Tool;
+import eu.itesla_project.commons.tools.ToolRunningContext;
+import eu.itesla_project.security.SecurityAnalyzer.Format;
+import eu.itesla_project.security.json.SecurityAnalysisResultSerializer;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
@@ -17,21 +30,6 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-
-import com.google.auto.service.AutoService;
-
-import eu.itesla_project.commons.io.table.AsciiTableFormatterFactory;
-import eu.itesla_project.commons.io.table.CsvTableFormatterFactory;
-import eu.itesla_project.commons.tools.Command;
-import eu.itesla_project.commons.tools.Tool;
-import eu.itesla_project.commons.tools.ToolRunningContext;
-import eu.itesla_project.security.json.SecurityAnalysisResultSerializer;
-import eu.itesla_project.security.SecurityAnalyzer.Format;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -119,7 +117,8 @@ public class SecurityAnalysisTool implements Tool {
         if (!result.getPreContingencyResult().isComputationOk()) {
             context.getErrorStream().println("Pre-contingency state divergence");
         }
-        LimitViolationFilter limitViolationFilter = new LimitViolationFilter(limitViolationTypes);
+        LimitViolationFilter limitViolationFilter = LimitViolationFilter.load();
+        limitViolationFilter.setViolationTypes(limitViolationTypes);
         if (outputFile != null) {
             exportResult(result, limitViolationFilter, context, outputFile, format);
         } else {

--- a/security-analysis/src/main/java/eu/itesla_project/security/json/LimitViolationDeserializer.java
+++ b/security-analysis/src/main/java/eu/itesla_project/security/json/LimitViolationDeserializer.java
@@ -29,14 +29,14 @@ class LimitViolationDeserializer extends StdDeserializer<LimitViolation> {
     public LimitViolation deserialize(JsonParser parser, DeserializationContext deserializationContext) throws IOException {
         String subjectId = null;
         LimitViolationType limitType = null;
-        float limit = Float.NaN;
         String limitName = null;
+        float limit = Float.NaN;
         float limitReduction = Float.NaN;
         float value = Float.NaN;
         Country country = null;
         float baseVoltage = Float.NaN;
 
-        while (parser.nextToken()  != JsonToken.END_OBJECT) {
+        while (parser.nextToken() != JsonToken.END_OBJECT) {
             switch (parser.getCurrentName()) {
                 case "subjectId":
                     subjectId = parser.nextTextValue();
@@ -47,13 +47,13 @@ class LimitViolationDeserializer extends StdDeserializer<LimitViolation> {
                     limitType = parser.readValueAs(LimitViolationType.class);
                     break;
 
+                case "limitName":
+                    limitName = parser.nextTextValue();
+                    break;
+
                 case "limit":
                     parser.nextToken();
                     limit = parser.readValueAs(Float.class);
-                    break;
-
-                case "limitName":
-                    limitName = parser.nextTextValue();
                     break;
 
                 case "limitReduction":
@@ -82,7 +82,5 @@ class LimitViolationDeserializer extends StdDeserializer<LimitViolation> {
         }
 
         return new LimitViolation(subjectId, limitType, limit, limitName, limitReduction, value, country, baseVoltage);
-
-
     }
 }

--- a/security-analysis/src/main/java/eu/itesla_project/security/json/LimitViolationSerializer.java
+++ b/security-analysis/src/main/java/eu/itesla_project/security/json/LimitViolationSerializer.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2017, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package eu.itesla_project.security.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import eu.itesla_project.commons.json.JsonUtil;
+import eu.itesla_project.security.LimitViolation;
+
+import java.io.IOException;
+
+/**
+ * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ */
+public class LimitViolationSerializer extends StdSerializer<LimitViolation> {
+
+    public LimitViolationSerializer() {
+        super(LimitViolation.class);
+    }
+
+    @Override
+    public void serialize(LimitViolation limitViolation, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeStartObject();
+
+        jsonGenerator.writeStringField("subjectId", limitViolation.getSubjectId());
+        jsonGenerator.writeStringField("limitType", limitViolation.getLimitType().name());
+        JsonUtil.writeOptionalStringField(jsonGenerator, "limitName", limitViolation.getLimitName());
+        jsonGenerator.writeNumberField("limit", limitViolation.getLimit());
+        jsonGenerator.writeNumberField("limitReduction", limitViolation.getLimitReduction());
+        jsonGenerator.writeNumberField("value", limitViolation.getValue());
+        JsonUtil.writeOptionalEnumField(jsonGenerator, "country", limitViolation.getCountry());
+        JsonUtil.writeOptionalFloatField(jsonGenerator, "baseVoltage", limitViolation.getBaseVoltage());
+
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/security-analysis/src/main/java/eu/itesla_project/security/json/SecurityAnalysisResultDeserializer.java
+++ b/security-analysis/src/main/java/eu/itesla_project/security/json/SecurityAnalysisResultDeserializer.java
@@ -6,6 +6,23 @@
  */
 package eu.itesla_project.security.json;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import eu.itesla_project.contingency.Contingency;
+import eu.itesla_project.contingency.ContingencyElement;
+import eu.itesla_project.contingency.json.ContingencyDeserializer;
+import eu.itesla_project.contingency.json.ContingencyElementDeserializer;
+import eu.itesla_project.security.LimitViolation;
+import eu.itesla_project.security.LimitViolationsResult;
+import eu.itesla_project.security.PostContingencyResult;
+import eu.itesla_project.security.SecurityAnalysisResult;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -15,17 +32,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-
-import eu.itesla_project.contingency.*;
-import eu.itesla_project.contingency.json.ContingencyDeserializer;
-import eu.itesla_project.contingency.json.ContingencyElementDeserializer;
-import eu.itesla_project.security.*;
 
 /**
  *

--- a/security-analysis/src/main/java/eu/itesla_project/security/json/SecurityAnalysisResultSerializer.java
+++ b/security-analysis/src/main/java/eu/itesla_project/security/json/SecurityAnalysisResultSerializer.java
@@ -6,18 +6,15 @@
  */
 package eu.itesla_project.security.json;
 
-import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import eu.itesla_project.security.LimitViolationFilter;
-import eu.itesla_project.security.LimitViolationsResult;
-import eu.itesla_project.security.PostContingencyResult;
-import eu.itesla_project.security.SecurityAnalysisResult;
+import eu.itesla_project.contingency.ContingencyElement;
+import eu.itesla_project.contingency.json.ContingencyElementSerializer;
+import eu.itesla_project.security.*;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -60,8 +57,7 @@ public class SecurityAnalysisResultSerializer extends StdSerializer<SecurityAnal
         }
     }
 
-    public static void write(SecurityAnalysisResult result, LimitViolationFilter filter,
-            OutputStream out) throws JsonGenerationException, JsonMappingException, IOException {
+    public static void write(SecurityAnalysisResult result, LimitViolationFilter filter, OutputStream out) throws IOException {
         Objects.requireNonNull(result);
         Objects.requireNonNull(filter);
         Objects.requireNonNull(out);
@@ -70,6 +66,8 @@ public class SecurityAnalysisResultSerializer extends StdSerializer<SecurityAnal
         module.addSerializer(SecurityAnalysisResult.class, new SecurityAnalysisResultSerializer());
         module.addSerializer(PostContingencyResult.class, new PostContingencyResultSerializer());
         module.addSerializer(LimitViolationsResult.class, new LimitViolationsResultSerializer(filter));
+        module.addSerializer(LimitViolation.class, new LimitViolationSerializer());
+        module.addSerializer(ContingencyElement.class, new ContingencyElementSerializer());
         objectMapper.registerModule(module);
 
         ObjectWriter writer = objectMapper.writerWithDefaultPrettyPrinter();

--- a/security-analysis/src/test/java/eu/itesla_project/security/SecurityTest.java
+++ b/security-analysis/src/test/java/eu/itesla_project/security/SecurityTest.java
@@ -122,7 +122,7 @@ public class SecurityTest {
         ((Bus) network.getIdentifiable("NHV2")).setV(380f).getVoltageLevel().setLowVoltageLimit(300f).setHighVoltageLimit(500f);
         network.getLine("NHV1_NHV2_1").getTerminal1().setP(560f).setQ(550f);
         network.getLine("NHV1_NHV2_1").getTerminal2().setP(560f).setQ(550f);
-        network.getLine("NHV1_NHV2_1").newCurrentLimits1().setPermanentLimit(1500f).add();
+        network.getLine("NHV1_NHV2_1").newCurrentLimits1().setPermanentLimit(500f).add();
         network.getLine("NHV1_NHV2_1").newCurrentLimits2()
             .setPermanentLimit(1100f)
             .beginTemporaryLimit()
@@ -141,11 +141,11 @@ public class SecurityTest {
                 .setValue(1200)
             .endTemporaryLimit()
             .add();
-        network.getLine("NHV1_NHV2_2").newCurrentLimits2().setPermanentLimit(1500f).add();
+        network.getLine("NHV1_NHV2_2").newCurrentLimits2().setPermanentLimit(500f).add();
 
         List<LimitViolation> violations = Security.checkLimits(network);
 
-        assertEquals(3, violations.size());
+        assertEquals(5, violations.size());
         violations.forEach(violation -> {
             assertTrue(Arrays.asList("VLHV1", "NHV1_NHV2_1", "NHV1_NHV2_2").contains(violation.getSubjectId()));
             if ("VLHV1".equals(violation.getSubjectId())) {
@@ -157,7 +157,7 @@ public class SecurityTest {
 
         violations = Security.checkLimits(network, 1);
 
-        assertEquals(3, violations.size());
+        assertEquals(5, violations.size());
         violations.forEach(violation ->  {
             assertTrue(Arrays.asList("VLHV1", "NHV1_NHV2_1", "NHV1_NHV2_2").contains(violation.getSubjectId()));
             if ("VLHV1".equals(violation.getSubjectId())) {

--- a/security-analysis/src/test/java/eu/itesla_project/security/SecurityTest.java
+++ b/security-analysis/src/test/java/eu/itesla_project/security/SecurityTest.java
@@ -6,8 +6,15 @@
  */
 package eu.itesla_project.security;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import eu.itesla_project.commons.io.table.CsvTableFormatterFactory;
+import eu.itesla_project.commons.io.table.TableFormatterConfig;
+import eu.itesla_project.contingency.Contingency;
+import eu.itesla_project.iidm.network.Bus;
+import eu.itesla_project.iidm.network.Network;
+import eu.itesla_project.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.StringWriter;
 import java.util.Arrays;
@@ -15,17 +22,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-
-import eu.itesla_project.commons.io.table.CsvTableFormatterFactory;
-import eu.itesla_project.commons.io.table.TableFormatterConfig;
-import eu.itesla_project.contingency.Contingency;
-import eu.itesla_project.iidm.network.Bus;
-import eu.itesla_project.iidm.network.Network;
-import eu.itesla_project.iidm.network.test.EurostagTutorialExample1Factory;
-import eu.itesla_project.security.Security.CurrentLimitType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -64,7 +62,7 @@ public class SecurityTest {
         }
         assertEquals(String.join(System.lineSeparator(),
                                  "Pre-contingency violations",
-                                 "Action,Equipment,Violation type,Violation name,Value,Limit,Charge %",
+                                 "Action,Equipment,Violation type,Violation name,Value,Limit,Loading rate %",
                                  "action1,,,,,,",
                                  ",line1,CURRENT,20',1100.00,1000.0,110"),
                      writer.toString().trim());
@@ -80,7 +78,7 @@ public class SecurityTest {
         }
         assertEquals(String.join(System.lineSeparator(),
                                  "Post-contingency limit violations",
-                                 "Contingency,Status,Action,Equipment,Violation type,Violation name,Value,Limit,Charge %",
+                                 "Contingency,Status,Action,Equipment,Violation type,Violation name,Value,Limit,Loading rate %",
                                  "contingency1,converge,,,,,,,",
                                  ",,action2,,,,,,",
                                  ",,,line1,CURRENT,20',1100.00,1000.0,110",
@@ -98,7 +96,7 @@ public class SecurityTest {
         }
         assertEquals(String.join(System.lineSeparator(),
                                  "Post-contingency limit violations",
-                                 "Contingency,Status,Action,Equipment,Violation type,Violation name,Value,Limit,Charge %",
+                                 "Contingency,Status,Action,Equipment,Violation type,Violation name,Value,Limit,Loading rate %",
                                  "contingency1,converge,,,,,,,",
                                  ",,action2,,,,,,",
                                  ",,,line2,CURRENT,10',950.000,900.0,106"),
@@ -108,12 +106,12 @@ public class SecurityTest {
     @Test
     public void printLimitsViolations() {
         assertEquals(String.join("\n",
-                                 "+---------+--------------+---------------+----------------+----------------+--------+--------+------------------+----------+",
-                                 "| Country | Base voltage | Equipment (2) | Violation type | Violation name | value  | limit  | abs(value-limit) | charge % |",
-                                 "+---------+--------------+---------------+----------------+----------------+--------+--------+------------------+----------+",
-                                 "|         |              | line1         | CURRENT        | 20'            | 1100.0 | 1000.0 | 100.0            | 110      |",
-                                 "|         |              | line2         | CURRENT        | 10'            | 950.0  | 900.0  | 50.0             | 106      |",
-                                 "+---------+--------------+---------------+----------------+----------------+--------+--------+------------------+----------+"),
+                                 "+---------+--------------+---------------+----------------+----------------+--------+--------+------------------+----------------+",
+                                 "| Country | Base voltage | Equipment (2) | Violation type | Violation name | Value  | Limit  | abs(value-limit) | Loading rate % |",
+                                 "+---------+--------------+---------------+----------------+----------------+--------+--------+------------------+----------------+",
+                                 "|         |              | line1         | CURRENT        | 20'            | 1100.0 | 1000.0 | 100.0            | 110            |",
+                                 "|         |              | line2         | CURRENT        | 10'            | 950.0  | 900.0  | 50.0             | 106            |",
+                                 "+---------+--------------+---------------+----------------+----------------+--------+--------+------------------+----------------+"),
                      Security.printLimitsViolations(Arrays.asList(line1Violation, line2Violation), new LimitViolationFilter()));
     }
 
@@ -157,7 +155,7 @@ public class SecurityTest {
             }
         });
 
-        violations = Security.checkLimits(network, CurrentLimitType.TATL, 1);
+        violations = Security.checkLimits(network, 1);
 
         assertEquals(3, violations.size());
         violations.forEach(violation ->  {

--- a/security-analysis/src/test/java/eu/itesla_project/security/json/SecurityAnalysisResultJsonTest.java
+++ b/security-analysis/src/test/java/eu/itesla_project/security/json/SecurityAnalysisResultJsonTest.java
@@ -8,7 +8,6 @@ package eu.itesla_project.security.json;
 
 import eu.itesla_project.commons.AbstractConverterTest;
 import eu.itesla_project.contingency.*;
-import eu.itesla_project.iidm.network.Country;
 import eu.itesla_project.security.*;
 import org.junit.Test;
 
@@ -23,8 +22,10 @@ import java.util.List;
 public class SecurityAnalysisResultJsonTest extends AbstractConverterTest {
 
     private static SecurityAnalysisResult create() {
-        LimitViolation violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, 100f, "limit", .95f, 110f, Country.FR, 380f);
-        LimitViolation violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, 100f, null, 110f);
+        // Create a LimitViolation(CURRENT) to ensure backward compatibility works
+        LimitViolation violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, 100f, "limit", 0.95f, 110f, null, Float.NaN);
+        LimitViolation violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, 100f, "20'", 110f);
+        LimitViolation violation3 = new LimitViolation("GEN", LimitViolationType.HIGH_VOLTAGE, 100f, null, 0.9f, 110f, null, Float.NaN);
 
         List<ContingencyElement> elements = Arrays.asList(
                 new BranchContingency("NHV1_NHV2_2", "VLNHV1"),
@@ -35,7 +36,7 @@ public class SecurityAnalysisResultJsonTest extends AbstractConverterTest {
         Contingency contingency = new ContingencyImpl("contingency", elements);
 
         LimitViolationsResult preContingencyResult = new LimitViolationsResult(true, Collections.singletonList(violation1));
-        PostContingencyResult postContingencyResult = new PostContingencyResult(contingency, true, Arrays.asList(violation1, violation2), Arrays.asList("action1", "action2"));
+        PostContingencyResult postContingencyResult = new PostContingencyResult(contingency, true, Arrays.asList(violation2, violation3), Arrays.asList("action1", "action2"));
 
         return new SecurityAnalysisResult(preContingencyResult, Collections.singletonList(postContingencyResult));
     }

--- a/security-analysis/src/test/java/eu/itesla_project/security/json/SecurityAnalysisResultJsonTest.java
+++ b/security-analysis/src/test/java/eu/itesla_project/security/json/SecurityAnalysisResultJsonTest.java
@@ -8,6 +8,7 @@ package eu.itesla_project.security.json;
 
 import eu.itesla_project.commons.AbstractConverterTest;
 import eu.itesla_project.contingency.*;
+import eu.itesla_project.iidm.network.Country;
 import eu.itesla_project.security.*;
 import org.junit.Test;
 
@@ -26,6 +27,7 @@ public class SecurityAnalysisResultJsonTest extends AbstractConverterTest {
         LimitViolation violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, 100f, "limit", 0.95f, 110f, null, Float.NaN);
         LimitViolation violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, 100f, "20'", 110f);
         LimitViolation violation3 = new LimitViolation("GEN", LimitViolationType.HIGH_VOLTAGE, 100f, null, 0.9f, 110f, null, Float.NaN);
+        LimitViolation violation4 = new LimitViolation("GEN2", LimitViolationType.LOW_VOLTAGE, 100f, null, 0.7f, 115f, Country.FR, 400.0f);
 
         List<ContingencyElement> elements = Arrays.asList(
                 new BranchContingency("NHV1_NHV2_2", "VLNHV1"),
@@ -36,7 +38,7 @@ public class SecurityAnalysisResultJsonTest extends AbstractConverterTest {
         Contingency contingency = new ContingencyImpl("contingency", elements);
 
         LimitViolationsResult preContingencyResult = new LimitViolationsResult(true, Collections.singletonList(violation1));
-        PostContingencyResult postContingencyResult = new PostContingencyResult(contingency, true, Arrays.asList(violation2, violation3), Arrays.asList("action1", "action2"));
+        PostContingencyResult postContingencyResult = new PostContingencyResult(contingency, true, Arrays.asList(violation2, violation3, violation4), Arrays.asList("action1", "action2"));
 
         return new SecurityAnalysisResult(preContingencyResult, Collections.singletonList(postContingencyResult));
     }

--- a/security-analysis/src/test/resources/SecurityAnalysisResult.json
+++ b/security-analysis/src/test/resources/SecurityAnalysisResult.json
@@ -5,12 +5,10 @@
     "limitViolations" : [ {
       "subjectId" : "NHV1_NHV2_1",
       "limitType" : "CURRENT",
-      "limit" : 100.0,
       "limitName" : "limit",
+      "limit" : 100.0,
       "limitReduction" : 0.95,
-      "value" : 110.0,
-      "country" : "FR",
-      "baseVoltage" : 380.0
+      "value" : 110.0
     } ],
     "actionsTaken" : [ ]
   },
@@ -19,11 +17,10 @@
       "id" : "contingency",
       "elements" : [ {
         "id" : "NHV1_NHV2_2",
-        "voltageLevelId" : "VLNHV1",
-        "type" : "BRANCH"
+        "type" : "BRANCH",
+        "voltageLevelId" : "VLNHV1"
       }, {
         "id" : "NHV1_NHV2_1",
-        "voltageLevelId" : null,
         "type" : "BRANCH"
       }, {
         "id" : "GEN",
@@ -36,23 +33,18 @@
     "limitViolationsResult" : {
       "computationOk" : true,
       "limitViolations" : [ {
-        "subjectId" : "NHV1_NHV2_1",
-        "limitType" : "CURRENT",
-        "limit" : 100.0,
-        "limitName" : "limit",
-        "limitReduction" : 0.95,
-        "value" : 110.0,
-        "country" : "FR",
-        "baseVoltage" : 380.0
-      }, {
         "subjectId" : "NHV1_NHV2_2",
         "limitType" : "CURRENT",
+        "limitName" : "20'",
         "limit" : 100.0,
-        "limitName" : null,
         "limitReduction" : 1.0,
-        "value" : 110.0,
-        "country" : null,
-        "baseVoltage" : "NaN"
+        "value" : 110.0
+      }, {
+        "subjectId" : "GEN",
+        "limitType" : "HIGH_VOLTAGE",
+        "limit" : 100.0,
+        "limitReduction" : 0.9,
+        "value" : 110.0
       } ],
       "actionsTaken" : [ "action1", "action2" ]
     }

--- a/security-analysis/src/test/resources/SecurityAnalysisResult.json
+++ b/security-analysis/src/test/resources/SecurityAnalysisResult.json
@@ -45,6 +45,14 @@
         "limit" : 100.0,
         "limitReduction" : 0.9,
         "value" : 110.0
+      }, {
+        "subjectId" : "GEN2",
+        "limitType" : "LOW_VOLTAGE",
+        "limit" : 100.0,
+        "limitReduction" : 0.7,
+        "value" : 115.0,
+        "country" : "FR",
+        "baseVoltage" : 400.0
       } ],
       "actionsTaken" : [ "action1", "action2" ]
     }


### PR DESCRIPTION
Change the way to detect Current violation by looking for an Overload and eventually for a PATL overload
JSON Export: do not export NaN or null values for optional fields
ASCII Export:
- Rename "charge %" to "Loading rate %"
- For current limits, violation name is based on the acceptable duration to avoid mistake